### PR TITLE
#148 Fix infinite loop when word is too large for column

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -3040,6 +3040,10 @@ public class CommandLine {
                         break;
                     }
                 }
+                if (done == 0 && length(text) > columnValue.maxLength) {
+                    // The value is a single word that is too big to be written to the column. Write as much as we can.
+                    done = copy(text, columnValue, offset);
+                }
                 return done;
             }
             private static int copy(Text value, Text destination, int offset) {


### PR DESCRIPTION
Splits the word naively at the column boundary. Don't know if this is the best way but seems to pass all the tests, including the one I made to repro this issue.

Fixes #148 