### PR TITLE
Added ability to mask default values

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -1396,6 +1396,12 @@ public class CommandLine {
          * @return whether this option should be excluded from the usage message
          */
         boolean hidden() default false;
+
+        /**
+         * If specified (non-empty string), usage will show this string rather than a specified default value when found
+         * @return mask string
+         */
+        String defaultValueMask() default "";
     }
     /**
      * <p>
@@ -2267,6 +2273,11 @@ public class CommandLine {
             result.splitRegex(option.split());
             result.hidden(option.hidden());
             result.converters(DefaultFactory.createConverter(factory, option.converter()));
+            Object defaultValue = getDefaultValue(scope, field);
+            if(defaultValue != null && !option.defaultValueMask().isEmpty()) {
+                defaultValue = option.defaultValueMask();
+            }
+            result.defaultValue(defaultValue);
             initCommon(result, scope, field);
             return result;
         }
@@ -2296,13 +2307,13 @@ public class CommandLine {
             result.splitRegex(parameters.split());
             result.hidden(parameters.hidden());
             result.converters(DefaultFactory.createConverter(factory, parameters.converter()));
+            result.defaultValue(getDefaultValue(scope, field));
             initCommon(result, scope, field);
             return result;
         }
         private static void initCommon(ArgSpec result, Object scope, Field field) {
             field.setAccessible(true);
             result.type(field.getType()); // field type
-            result.defaultValue(getDefaultValue(scope, field));
             result.withToString(abbreviate("field " + field.toGenericString()));
             result.getter(new FieldGetter(scope, field));
             result.setter(new FieldSetter(scope, field));

--- a/src/test/java/picocli/CommandLineHelpTest.java
+++ b/src/test/java/picocli/CommandLineHelpTest.java
@@ -2900,4 +2900,18 @@ public class CommandLineHelpTest {
                 "  help  Displays help information about the specified command%n");
         assertEquals(expected, new String(baos.toByteArray(), "UTF-8"));
     }
+
+    @Test
+    public void testMaskDefaultOption() throws UnsupportedEncodingException {
+        @CommandLine.Command(showDefaultValues = true)
+        class Params {
+            @Option(names = {"-p"}, description = "password",defaultValueMask = "*********")
+            String password = "mypassword";
+        }
+        String result = usageString(new Params(), Help.Ansi.OFF);
+        assertEquals(format("" +
+                "Usage: <main class> [-p=<password>]%n" +
+                "  -p= <password>              password%n" +
+                "                                Default: *********%n"), result);
+    }
 }


### PR DESCRIPTION
This adds a defaultValueMask() value to @Option. 

When specified the string will be used instead of the default value (for example when the default value is sensitive and shouldn't be displayed like passwords and such.

Unit Test included