### PR TITLE
Various improvements to default values

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -2320,7 +2320,6 @@ public class CommandLine {
             result.hidden(option.hidden());
             result.converters(DefaultFactory.createConverter(factory, option.converter()));
             result.defaultValueMask(option.defaultValueMask());
-            result.defaultValue(getDefaultValue(scope, field));
             initCommon(result, scope, field);
             return result;
         }
@@ -2350,13 +2349,13 @@ public class CommandLine {
             result.splitRegex(parameters.split());
             result.hidden(parameters.hidden());
             result.converters(DefaultFactory.createConverter(factory, parameters.converter()));
-            result.defaultValue(getDefaultValue(scope, field));
             initCommon(result, scope, field);
             return result;
         }
         private static void initCommon(ArgSpec result, Object scope, Field field) {
             field.setAccessible(true);
             result.type(field.getType()); // field type
+            result.defaultValue(getDefaultValue(scope, field));
             result.withToString(abbreviate("field " + field.toGenericString()));
             result.getter(new FieldGetter(scope, field));
             result.setter(new FieldSetter(scope, field));

--- a/src/test/java/picocli/CommandLineHelpTest.java
+++ b/src/test/java/picocli/CommandLineHelpTest.java
@@ -2902,20 +2902,6 @@ public class CommandLineHelpTest {
     }
 
     @Test
-    public void testMaskDefaultOption() throws UnsupportedEncodingException {
-        @CommandLine.Command(showDefaultValues = true)
-        class Params {
-            @Option(names = {"-p"}, description = "password",defaultValueMask = "*********")
-            String password = "mypassword";
-        }
-        String result = usageString(new Params(), Help.Ansi.OFF);
-        assertEquals(format("" +
-                "Usage: <main class> [-p=<password>]%n" +
-                "  -p= <password>              password%n" +
-                "                                Default: *********%n"), result);
-    }
-
-    @Test
     public void testNotRequiredWithDefault() throws Exception {
         @CommandLine.Command(showDefaultValues = true, notRequiredWithDefault = true)
         class Params {
@@ -3019,20 +3005,6 @@ public class CommandLineHelpTest {
         } catch (CommandLine.MissingParameterException e) {
             // ok
         }
-    }
-
-    @Test
-    public void testMaskDefaultOption() throws UnsupportedEncodingException {
-        @CommandLine.Command(showDefaultValues = true)
-        class Params {
-            @Option(names = {"-p"}, description = "password", defaultValueMask = "*********")
-            String password = "mypassword";
-        }
-        String result = usageString(new Params(), Help.Ansi.OFF);
-        assertEquals(format("" +
-                "Usage: <main class> [-p=<password>]%n" +
-                "  -p= <password>              password%n" +
-                "                                Default: *********%n"), result);
     }
 
     @Test

--- a/src/test/java/picocli/CommandLineHelpTest.java
+++ b/src/test/java/picocli/CommandLineHelpTest.java
@@ -2900,4 +2900,184 @@ public class CommandLineHelpTest {
                 "  help  Displays help information about the specified command%n");
         assertEquals(expected, new String(baos.toByteArray(), "UTF-8"));
     }
+
+    @Test
+    public void testMaskDefaultOption() throws UnsupportedEncodingException {
+        @CommandLine.Command(showDefaultValues = true)
+        class Params {
+            @Option(names = {"-p"}, description = "password",defaultValueMask = "*********")
+            String password = "mypassword";
+        }
+        String result = usageString(new Params(), Help.Ansi.OFF);
+        assertEquals(format("" +
+                "Usage: <main class> [-p=<password>]%n" +
+                "  -p= <password>              password%n" +
+                "                                Default: *********%n"), result);
+    }
+
+    @Test
+    public void testNotRequiredWithDefault() throws Exception {
+        @CommandLine.Command(showDefaultValues = true, notRequiredWithDefault = true)
+        class Params {
+            @Option(names = {"-f", "--file"}, required = true, description = "the file to use")
+            File file = new File("theDefault.txt");
+        }
+        String result = usageString(new Params(), Help.Ansi.OFF);
+        assertEquals(format("" +
+                "Usage: <main class> [-f=<file>]%n" +
+                "  -f, --file=<file>           the file to use%n" +
+                "                                Default: theDefault.txt%n"), result);
+    }
+
+    @Test
+    public void testNotRequiredWithDefaultRefreshedAddRequired() throws Exception {
+        @CommandLine.Command(showDefaultValues = true, notRequiredWithDefault = true)
+        class Params {
+            @Option(names = {"-f", "--file"}, required = true, description = "the file to use")
+            File file;
+        }
+        Params command = new Params();
+        CommandLine commandLine = new CommandLine(command);
+        String result = usageString(commandLine, Help.Ansi.OFF);
+        assertEquals(format("" +
+                "Usage: <main class> -f=<file>%n" +
+                "  -f, --file=<file>           the file to use%n"), result);
+        try {
+            commandLine.parse();
+            fail("should have failed with MissingParameterException");
+        } catch (CommandLine.MissingParameterException e) {
+            // ok
+        }
+        command.file = new File("theDefault.txt");
+        commandLine.refreshDefaultValues();
+        result = usageString(commandLine, Help.Ansi.OFF);
+        assertEquals(format("" +
+                "Usage: <main class> [-f=<file>]%n" +
+                "  -f, --file=<file>           the file to use%n" +
+                "                                Default: theDefault.txt%n"), result);
+        commandLine.parse();
+    }
+
+    @Test
+    public void testRequiredNotRemovedAfterRefresh() throws Exception {
+        @CommandLine.Command(showDefaultValues = true)
+        class Params {
+            @Option(names = {"-f", "--file"}, required = true, description = "the file to use")
+            File file;
+        }
+        Params command = new Params();
+        CommandLine commandLine = new CommandLine(command);
+        String result = usageString(commandLine, Help.Ansi.OFF);
+        assertEquals(format("" +
+                "Usage: <main class> -f=<file>%n" +
+                "  -f, --file=<file>           the file to use%n"), result);
+        try {
+            commandLine.parse();
+            fail("should have failed with MissingParameterException");
+        } catch (CommandLine.MissingParameterException e) {
+            // ok
+        }
+        command.file = new File("theDefault.txt");
+        commandLine.refreshDefaultValues();
+        result = usageString(commandLine, Help.Ansi.OFF);
+        assertEquals(format("" +
+                "Usage: <main class> -f=<file>%n" +
+                "  -f, --file=<file>           the file to use%n" +
+                "                                Default: theDefault.txt%n"), result);
+        try {
+            commandLine.parse();
+            fail("should have failed with MissingParameterException");
+        } catch (CommandLine.MissingParameterException e) {
+            // ok
+        }
+    }
+
+    @Test
+    public void testNotRequiredWithDefaultRefreshedRemoveRequired() throws Exception {
+        @CommandLine.Command(showDefaultValues = true, notRequiredWithDefault = true)
+        class Params {
+            @Option(names = {"-f", "--file"}, required = true, description = "the file to use")
+            File file = new File("theDefault.txt");
+        }
+        Params command = new Params();
+        CommandLine commandLine = new CommandLine(command);
+        String result = usageString(commandLine, Help.Ansi.OFF);
+        assertEquals(format("" +
+                "Usage: <main class> [-f=<file>]%n" +
+                "  -f, --file=<file>           the file to use%n" +
+                "                                Default: theDefault.txt%n"), result);
+        commandLine.parse();
+        command.file = null;
+        commandLine.refreshDefaultValues();
+        result = usageString(commandLine, Help.Ansi.OFF);
+        assertEquals(format("" +
+                "Usage: <main class> -f=<file>%n" +
+                "  -f, --file=<file>           the file to use%n"), result);
+        try {
+            commandLine.parse();
+            fail("should have failed with MissingParameterException");
+        } catch (CommandLine.MissingParameterException e) {
+            // ok
+        }
+    }
+
+    @Test
+    public void testMaskDefaultOption() throws UnsupportedEncodingException {
+        @CommandLine.Command(showDefaultValues = true)
+        class Params {
+            @Option(names = {"-p"}, description = "password", defaultValueMask = "*********")
+            String password = "mypassword";
+        }
+        String result = usageString(new Params(), Help.Ansi.OFF);
+        assertEquals(format("" +
+                "Usage: <main class> [-p=<password>]%n" +
+                "  -p= <password>              password%n" +
+                "                                Default: *********%n"), result);
+    }
+
+    @Test
+    public void testMaskDefaultOptionStillMaskedAfterRefresh() throws UnsupportedEncodingException {
+        @CommandLine.Command(name = "cmd",showDefaultValues = true)
+        class Params {
+            @Option(names = {"-p"}, description = "password", defaultValueMask = "PASSWORDMASK")
+            String password = "mypassword";
+        }
+        @CommandLine.Command(name = "subcmd",showDefaultValues = true)
+        class SubParams {
+            @Option(names = {"-k"}, description = "key", defaultValueMask = "KEYMASK")
+            String key = "mykey";
+        }
+        CommandLine commandLine = new CommandLine(new Params());
+        CommandLine subCommandLine = new CommandLine(new SubParams());
+        commandLine.addSubcommand("subcmd", subCommandLine);
+        String expectedCmdUsage = format("" +
+                "Usage: cmd [-p=<password>]%n" +
+                "  -p= <password>              password%n" +
+                "                                Default: PASSWORDMASK%n" +
+                "Commands:%n" +
+                "  subcmd%n");
+        String expectedSubCmdUsage = format("" +
+                "Usage: subcmd [-k=<key>]%n" +
+                "  -k= <key>                   key%n" +
+                "                                Default: KEYMASK%n");
+        assertEquals(expectedCmdUsage, usageString(commandLine, Help.Ansi.OFF));
+        assertEquals(expectedSubCmdUsage, usageString(subCommandLine, Help.Ansi.OFF));
+        commandLine.refreshDefaultValues();
+        assertEquals(expectedCmdUsage, usageString(commandLine, Help.Ansi.OFF));
+        assertEquals(expectedSubCmdUsage, usageString(subCommandLine, Help.Ansi.OFF));
+    }
+
+    @Test
+    public void testMaskDefaultOption() throws UnsupportedEncodingException {
+        @CommandLine.Command(showDefaultValues = true)
+        class Params {
+            @Option(names = {"-p"}, description = "password",defaultValueMask = "*********")
+            String password = "mypassword";
+        }
+        String result = usageString(new Params(), Help.Ansi.OFF);
+        assertEquals(format("" +
+                "Usage: <main class> [-p=<password>]%n" +
+                "  -p= <password>              password%n" +
+                "                                Default: *********%n"), result);
+    }
 }

--- a/src/test/java/picocli/CommandLineTest.java
+++ b/src/test/java/picocli/CommandLineTest.java
@@ -3267,6 +3267,17 @@ public class CommandLineTest {
         assertFalse("never invoked", app.xxx);
     }
 
+    @Test
+    public void testIgnoreRequired() {
+        class App {
+            @Option(names = "-x",required = true)
+            private boolean xxx;
+        }
+        App app = new App();
+        CommandLine commandLine = new CommandLine(app).setIgnoreRequired(true);
+        commandLine.parse();
+    }
+
     private void copyFile(File source, File destination) throws IOException {
         InputStream in = null;
         OutputStream out = null;


### PR DESCRIPTION
Various improvements to default values (standard behavior remains the same, all features are options and must be enabled explicitely):

- bugfix: Default values couldn't be read from non-public fields (was missing setAccessible())
- mask default value: This allows to specify a mask string in @Options that will be displayed instead of any existing default value (will not be displayed if no default value exists)
- notRequiredWithDefault in @Command allows a default value in a required field to become non-required
- refreshDefaultValues() added to CommandLine

Unit tests for all features included