### PR TITLE
Avoid to overwrite compile time frozen value in Kotlin examples

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -2305,15 +2305,15 @@ class MyApp : Runnable {
 
     @Option(names = ["-c", "--count"], paramLabel = "COUNT",
             description = ["the count"])
-    private val count: Int = 0
+    private var count: Int = 0
 
     @Option(names = ["-h", "--help"], usageHelp = true,
             description = ["print this help and exit"])
-    private val helpRequested: Boolean = false
+    private var helpRequested: Boolean = false
 
     @Option(names = ["-V", "--version"], versionHelp = true,
             description = ["print version info and exit"])
-    private val versionRequested: Boolean = false
+    private var versionRequested: Boolean = false
 
     override fun run() {
         for (i in 0 until count) {
@@ -2338,15 +2338,15 @@ class MyApp : Runnable {
 
     @Option(names = arrayOf("-c", "--count"), paramLabel = "COUNT",
             description = arrayOf("the count"))
-    private val count: Int = 0
+    private var count: Int = 0
 
     @Option(names = arrayOf("-h", "--help"), usageHelp = true,
             description = arrayOf("print this help and exit"))
-    private val helpRequested: Boolean = false
+    private var helpRequested: Boolean = false
 
     @Option(names = arrayOf("-V", "--version"), versionHelp = true,
             description = arrayOf("print version info and exit"))
-    private val versionRequested: Boolean = false
+    private var versionRequested: Boolean = false
 
     override fun run() {
         for (i in 0 until count) {


### PR DESCRIPTION
Current kotlin sample code causes an exception at runtime:

```log
Exception in thread "main" picocli.CommandLine$InitializationException: Constant (final) primitive and String fields like private final int picocli.example.MyApp.count cannot be used as an @Option: compile-time constant inlining may hide new values written to it.
	at picocli.CommandLine.init(CommandLine.java:1964)
	at picocli.CommandLine$Interpreter.<init>(CommandLine.java:2040)
	at picocli.CommandLine.<init>(CommandLine.java:178)
	at picocli.CommandLine.<init>(CommandLine.java:167)
	at picocli.CommandLine.run(CommandLine.java:971)
	at picocli.CommandLine.run(CommandLine.java:925)
	at picocli.example.MyApp$Companion.main(MyApp.kt:29)
	at picocli.example.MyApp.main(MyApp.kt)

Process finished with exit code 1
```

Tested on https://github.com/cosmo0920/picocli-example-kotlin.

---

Language version 1.2: [master branch](https://github.com/cosmo0920/picocli-example-kotlin/tree/master)
Language version 1.1: [kotlin-lang-1.1 branch](https://github.com/cosmo0920/picocli-example-kotlin/tree/kotlin-lang-1.1)

---

Environment: macOS 10.13.2
picocli version: 2.2.1