### PR TITLE
Require at least Java 7?

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,8 @@ buildscript {
 allprojects {
     apply plugin: 'groovy'
     apply plugin: 'java'
-    sourceCompatibility = 1.5
-    targetCompatibility = 1.5
+    sourceCompatibility = 1.7
+    targetCompatibility = 1.7
 
     repositories {
         jcenter()


### PR DESCRIPTION
Java SE Public Updates has ended for Java 5 and Java 6. According to http://www.oracle.com/technetwork/java/eol-135779.html, Extended Support for Java 6 will end in December 2018. Thus, I propose to update this project to require at least Java 7.

- [x] Update build.gradle
- [ ] Update documentation