### PR TITLE
Fix autocomplete script errors in zsh

### DIFF
--- a/src/main/java/picocli/AutoComplete.java
+++ b/src/main/java/picocli/AutoComplete.java
@@ -263,6 +263,7 @@ public class AutoComplete {
             "elif [ -n \"$ZSH_VERSION\" ]; then\n" +
             "  # Make alias a distinct command for completion purposes when using zsh (see [4])\n" +
             "  setopt COMPLETE_ALIASES\n" +
+            "  alias compopt=complete\n" +
             "fi\n" +
             "\n" +
             "# ArrContains takes two arguments, both of which are the name of arrays.\n" +

--- a/src/main/java/picocli/AutoComplete.java
+++ b/src/main/java/picocli/AutoComplete.java
@@ -252,12 +252,18 @@ public class AutoComplete {
             "# [1] http://stackoverflow.com/a/12495480/1440785\n" +
             "# [2] http://tiswww.case.edu/php/chet/bash/FAQ\n" +
             "# [3] https://www.gnu.org/software/bash/manual/html_node/The-Shopt-Builtin.html\n" +
-            "# [4] https://stackoverflow.com/questions/17042057/bash-check-element-in-array-for-elements-in-another-array/17042655#17042655\n" +
-            "# [5] https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion.html#Programmable-Completion\n" +
+            "# [4] http://zsh.sourceforge.net/Doc/Release/Options.html#index-COMPLETE_005fALIASES\n" +
+            "# [5] https://stackoverflow.com/questions/17042057/bash-check-element-in-array-for-elements-in-another-array/17042655#17042655\n" +
+            "# [6] https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion.html#Programmable-Completion\n" +
             "#\n" +
             "\n" +
-            "# Enable programmable completion facilities (see [3])\n" +
-            "shopt -s progcomp\n" +
+            "if [ -n \"$BASH_VERSION\" ]; then\n" +
+            "  # Enable programmable completion facilities when using bash (see [3])\n" +
+            "  shopt -s progcomp\n" +
+            "elif [ -n \"$ZSH_VERSION\" ]; then\n" +
+            "  # Make alias a distinct command for completion purposes when using zsh (see [4])\n" +
+            "  setopt COMPLETE_ALIASES\n" +
+            "fi\n" +
             "\n" +
             "# ArrContains takes two arguments, both of which are the name of arrays.\n" +
             "# It creates a temporary hash from lArr1 and then checks if all elements of lArr2\n" +
@@ -266,7 +272,7 @@ public class AutoComplete {
             "# Returns zero (no error) if all elements of the 2nd array are in the 1st array,\n" +
             "# otherwise returns 1 (error).\n" +
             "#\n" +
-            "# Modified from [4]\n" +
+            "# Modified from [5]\n" +
             "function ArrContains() {\n" +
             "  local lArr1 lArr2\n" +
             "  declare -A tmp\n" +
@@ -282,7 +288,7 @@ public class AutoComplete {
             "\n" +
             "# Define a completion specification (a compspec) for the\n" +
             "# `%1$s`, `%1$s.sh`, and `%1$s.bash` commands.\n" +
-            "# Uses the bash `complete` builtin (see [5]) to specify that shell function\n" +
+            "# Uses the bash `complete` builtin (see [6]) to specify that shell function\n" +
             "# `_complete_%1$s` is responsible for generating possible completions for the\n" +
             "# current word on the command line.\n" +
             "# The `-o default` option means that if the function generated no matches, the\n" +

--- a/src/test/java/picocli/AutoCompleteTest.java
+++ b/src/test/java/picocli/AutoCompleteTest.java
@@ -343,12 +343,18 @@ public class AutoCompleteTest {
                 "# [1] http://stackoverflow.com/a/12495480/1440785\n" +
                 "# [2] http://tiswww.case.edu/php/chet/bash/FAQ\n" +
                 "# [3] https://www.gnu.org/software/bash/manual/html_node/The-Shopt-Builtin.html\n" +
-                "# [4] https://stackoverflow.com/questions/17042057/bash-check-element-in-array-for-elements-in-another-array/17042655#17042655\n" +
-                "# [5] https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion.html#Programmable-Completion\n" +
+                "# [4] http://zsh.sourceforge.net/Doc/Release/Options.html#index-COMPLETE_005fALIASES\n" +
+                "# [5] https://stackoverflow.com/questions/17042057/bash-check-element-in-array-for-elements-in-another-array/17042655#17042655\n" +
+                "# [6] https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion.html#Programmable-Completion\n" +
                 "#\n" +
                 "\n" +
-                "# Enable programmable completion facilities (see [3])\n" +
-                "shopt -s progcomp\n" +
+                "if [ -n \"$BASH_VERSION\" ]; then\n" +
+                "  # Enable programmable completion facilities when using bash (see [3])\n" +
+                "  shopt -s progcomp\n" +
+                "elif [ -n \"$ZSH_VERSION\" ]; then\n" +
+                "  # Make alias a distinct command for completion purposes when using zsh (see [4])\n" +
+                "  setopt COMPLETE_ALIASES\n" +
+                "fi\n" +
                 "\n" +
                 "# ArrContains takes two arguments, both of which are the name of arrays.\n" +
                 "# It creates a temporary hash from lArr1 and then checks if all elements of lArr2\n" +
@@ -357,7 +363,7 @@ public class AutoCompleteTest {
                 "# Returns zero (no error) if all elements of the 2nd array are in the 1st array,\n" +
                 "# otherwise returns 1 (error).\n" +
                 "#\n" +
-                "# Modified from [4]\n" +
+                "# Modified from [5]\n" +
                 "function ArrContains() {\n" +
                 "  local lArr1 lArr2\n" +
                 "  declare -A tmp\n" +
@@ -410,7 +416,7 @@ public class AutoCompleteTest {
                 "\n" +
                 "# Define a completion specification (a compspec) for the\n" +
                 "# `picocli.AutoComplete`, `picocli.AutoComplete.sh`, and `picocli.AutoComplete.bash` commands.\n" +
-                "# Uses the bash `complete` builtin (see [5]) to specify that shell function\n" +
+                "# Uses the bash `complete` builtin (see [6]) to specify that shell function\n" +
                 "# `_complete_picocli.AutoComplete` is responsible for generating possible completions for the\n" +
                 "# current word on the command line.\n" +
                 "# The `-o default` option means that if the function generated no matches, the\n" +

--- a/src/test/java/picocli/AutoCompleteTest.java
+++ b/src/test/java/picocli/AutoCompleteTest.java
@@ -354,6 +354,7 @@ public class AutoCompleteTest {
                 "elif [ -n \"$ZSH_VERSION\" ]; then\n" +
                 "  # Make alias a distinct command for completion purposes when using zsh (see [4])\n" +
                 "  setopt COMPLETE_ALIASES\n" +
+                "  alias compopt=complete\n" +
                 "fi\n" +
                 "\n" +
                 "# ArrContains takes two arguments, both of which are the name of arrays.\n" +

--- a/src/test/resources/basic.bash
+++ b/src/test/resources/basic.bash
@@ -47,6 +47,7 @@ if [ -n "$BASH_VERSION" ]; then
 elif [ -n "$ZSH_VERSION" ]; then
   # Make alias a distinct command for completion purposes when using zsh (see [4])
   setopt COMPLETE_ALIASES
+  alias compopt=complete
 fi
 
 # ArrContains takes two arguments, both of which are the name of arrays.

--- a/src/test/resources/basic.bash
+++ b/src/test/resources/basic.bash
@@ -36,12 +36,18 @@
 # [1] http://stackoverflow.com/a/12495480/1440785
 # [2] http://tiswww.case.edu/php/chet/bash/FAQ
 # [3] https://www.gnu.org/software/bash/manual/html_node/The-Shopt-Builtin.html
-# [4] https://stackoverflow.com/questions/17042057/bash-check-element-in-array-for-elements-in-another-array/17042655#17042655
-# [5] https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion.html#Programmable-Completion
+# [4] http://zsh.sourceforge.net/Doc/Release/Options.html#index-COMPLETE_005fALIASES
+# [5] https://stackoverflow.com/questions/17042057/bash-check-element-in-array-for-elements-in-another-array/17042655#17042655
+# [6] https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion.html#Programmable-Completion
 #
 
-# Enable programmable completion facilities (see [3])
-shopt -s progcomp
+if [ -n "$BASH_VERSION" ]; then
+  # Enable programmable completion facilities when using bash (see [3])
+  shopt -s progcomp
+elif [ -n "$ZSH_VERSION" ]; then
+  # Make alias a distinct command for completion purposes when using zsh (see [4])
+  setopt COMPLETE_ALIASES
+fi
 
 # ArrContains takes two arguments, both of which are the name of arrays.
 # It creates a temporary hash from lArr1 and then checks if all elements of lArr2
@@ -50,7 +56,7 @@ shopt -s progcomp
 # Returns zero (no error) if all elements of the 2nd array are in the 1st array,
 # otherwise returns 1 (error).
 #
-# Modified from [4]
+# Modified from [5]
 function ArrContains() {
   local lArr1 lArr2
   declare -A tmp
@@ -102,7 +108,7 @@ function _picocli_basicExample() {
 
 # Define a completion specification (a compspec) for the
 # `basicExample`, `basicExample.sh`, and `basicExample.bash` commands.
-# Uses the bash `complete` builtin (see [5]) to specify that shell function
+# Uses the bash `complete` builtin (see [6]) to specify that shell function
 # `_complete_basicExample` is responsible for generating possible completions for the
 # current word on the command line.
 # The `-o default` option means that if the function generated no matches, the

--- a/src/test/resources/hyphenated_completion.bash
+++ b/src/test/resources/hyphenated_completion.bash
@@ -47,6 +47,7 @@ if [ -n "$BASH_VERSION" ]; then
 elif [ -n "$ZSH_VERSION" ]; then
   # Make alias a distinct command for completion purposes when using zsh (see [4])
   setopt COMPLETE_ALIASES
+  alias compopt=complete
 fi
 
 # ArrContains takes two arguments, both of which are the name of arrays.

--- a/src/test/resources/hyphenated_completion.bash
+++ b/src/test/resources/hyphenated_completion.bash
@@ -36,12 +36,18 @@
 # [1] http://stackoverflow.com/a/12495480/1440785
 # [2] http://tiswww.case.edu/php/chet/bash/FAQ
 # [3] https://www.gnu.org/software/bash/manual/html_node/The-Shopt-Builtin.html
-# [4] https://stackoverflow.com/questions/17042057/bash-check-element-in-array-for-elements-in-another-array/17042655#17042655
-# [5] https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion.html#Programmable-Completion
+# [4] http://zsh.sourceforge.net/Doc/Release/Options.html#index-COMPLETE_005fALIASES
+# [5] https://stackoverflow.com/questions/17042057/bash-check-element-in-array-for-elements-in-another-array/17042655#17042655
+# [6] https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion.html#Programmable-Completion
 #
 
-# Enable programmable completion facilities (see [3])
-shopt -s progcomp
+if [ -n "$BASH_VERSION" ]; then
+  # Enable programmable completion facilities when using bash (see [3])
+  shopt -s progcomp
+elif [ -n "$ZSH_VERSION" ]; then
+  # Make alias a distinct command for completion purposes when using zsh (see [4])
+  setopt COMPLETE_ALIASES
+fi
 
 # ArrContains takes two arguments, both of which are the name of arrays.
 # It creates a temporary hash from lArr1 and then checks if all elements of lArr2
@@ -50,7 +56,7 @@ shopt -s progcomp
 # Returns zero (no error) if all elements of the 2nd array are in the 1st array,
 # otherwise returns 1 (error).
 #
-# Modified from [4]
+# Modified from [5]
 function ArrContains() {
   local lArr1 lArr2
   declare -A tmp
@@ -117,7 +123,7 @@ function _picocli_rcmd_sub2() {
 
 # Define a completion specification (a compspec) for the
 # `rcmd`, `rcmd.sh`, and `rcmd.bash` commands.
-# Uses the bash `complete` builtin (see [5]) to specify that shell function
+# Uses the bash `complete` builtin (see [6]) to specify that shell function
 # `_complete_rcmd` is responsible for generating possible completions for the
 # current word on the command line.
 # The `-o default` option means that if the function generated no matches, the

--- a/src/test/resources/picocompletion-demo_completion.bash
+++ b/src/test/resources/picocompletion-demo_completion.bash
@@ -47,6 +47,7 @@ if [ -n "$BASH_VERSION" ]; then
 elif [ -n "$ZSH_VERSION" ]; then
   # Make alias a distinct command for completion purposes when using zsh (see [4])
   setopt COMPLETE_ALIASES
+  alias compopt=complete
 fi
 
 # ArrContains takes two arguments, both of which are the name of arrays.

--- a/src/test/resources/picocompletion-demo_completion.bash
+++ b/src/test/resources/picocompletion-demo_completion.bash
@@ -36,12 +36,18 @@
 # [1] http://stackoverflow.com/a/12495480/1440785
 # [2] http://tiswww.case.edu/php/chet/bash/FAQ
 # [3] https://www.gnu.org/software/bash/manual/html_node/The-Shopt-Builtin.html
-# [4] https://stackoverflow.com/questions/17042057/bash-check-element-in-array-for-elements-in-another-array/17042655#17042655
-# [5] https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion.html#Programmable-Completion
+# [4] http://zsh.sourceforge.net/Doc/Release/Options.html#index-COMPLETE_005fALIASES
+# [5] https://stackoverflow.com/questions/17042057/bash-check-element-in-array-for-elements-in-another-array/17042655#17042655
+# [6] https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion.html#Programmable-Completion
 #
 
-# Enable programmable completion facilities (see [3])
-shopt -s progcomp
+if [ -n "$BASH_VERSION" ]; then
+  # Enable programmable completion facilities when using bash (see [3])
+  shopt -s progcomp
+elif [ -n "$ZSH_VERSION" ]; then
+  # Make alias a distinct command for completion purposes when using zsh (see [4])
+  setopt COMPLETE_ALIASES
+fi
 
 # ArrContains takes two arguments, both of which are the name of arrays.
 # It creates a temporary hash from lArr1 and then checks if all elements of lArr2
@@ -50,7 +56,7 @@ shopt -s progcomp
 # Returns zero (no error) if all elements of the 2nd array are in the 1st array,
 # otherwise returns 1 (error).
 #
-# Modified from [4]
+# Modified from [5]
 function ArrContains() {
   local lArr1 lArr2
   declare -A tmp
@@ -209,7 +215,7 @@ function _picocli_picocompletion-demo_sub2_subsub2() {
 
 # Define a completion specification (a compspec) for the
 # `picocompletion-demo`, `picocompletion-demo.sh`, and `picocompletion-demo.bash` commands.
-# Uses the bash `complete` builtin (see [5]) to specify that shell function
+# Uses the bash `complete` builtin (see [6]) to specify that shell function
 # `_complete_picocompletion-demo` is responsible for generating possible completions for the
 # current word on the command line.
 # The `-o default` option means that if the function generated no matches, the


### PR DESCRIPTION
I've been testing the autocomplete script in `zsh`, and I came accross a few errors.

* `shopt` isn't available in `zsh`
* `compopt` doesn't seem to be understood in `zsh` even when using `bashcompinit`, `complete` with the same options works, I've added an alias when using `zsh` for `compopt`->`complete`
* added `setopt COMPLETE_ALIASES` when using zsh or the alias doesn't work properly when autocompleting

I've attempted to fix them by adding a check for the shell the script is being run under. I've tested the changes using Ubuntu Server 18.04 LTS and zsh 5.4.2, and Mac OS and zsh 5.5.1.
