### PR TITLE
#441: added support for fixing the paramLabel as-is and omit regular processing

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -3941,7 +3941,7 @@ public class CommandLine {
             // help-related fields
             private final boolean hidden;
             private final String paramLabel;
-            private final boolean fixParamLabel;
+            private final boolean showParamSyntax;
             private final String[] description;
             private final Help.Visibility showDefaultValue;
 
@@ -3970,7 +3970,7 @@ public class CommandLine {
                 description = builder.description == null ? new String[0] : builder.description;
                 splitRegex = builder.splitRegex == null ? "" : builder.splitRegex;
                 paramLabel = empty(builder.paramLabel) ? "PARAM" : builder.paramLabel;
-                fixParamLabel = builder.fixParamLabel;
+                showParamSyntax = builder.showParamSyntax;
                 converters = builder.converters == null ? new ITypeConverter<?>[0] : builder.converters;
                 showDefaultValue = builder.showDefaultValue == null ? Help.Visibility.ON_DEMAND : builder.showDefaultValue;
                 hidden = builder.hidden;
@@ -4075,8 +4075,8 @@ public class CommandLine {
             public String paramLabel()     { return paramLabel; }
     
             /** Indicates whether paramLabel should be processed the regular way or that it should be rendered as-is.
-             * @see #paramLabel()  {@link #fixParamLabel()} */
-            public boolean fixParamLabel()     { return fixParamLabel; }
+             * @see #paramLabel()  {@link #paramLabel()} */
+            public boolean showParamSyntax()     { return showParamSyntax; }
     
             /** Returns auxiliary type information used when the {@link #type()} is a generic {@code Collection}, {@code Map} or an abstract class.
              * @see Option#type() */
@@ -4245,7 +4245,7 @@ public class CommandLine {
                 private boolean required;
                 private boolean interactive;
                 private String paramLabel;
-                private boolean fixParamLabel;
+                private boolean showParamSyntax = true;
                 private String splitRegex;
                 private boolean hidden;
                 private Class<?> type;
@@ -4271,7 +4271,7 @@ public class CommandLine {
                     setter = original.setter;
                     hidden = original.hidden;
                     paramLabel = original.paramLabel;
-                    fixParamLabel = original.fixParamLabel;
+                    showParamSyntax = original.showParamSyntax;
                     required = original.required;
                     interactive = original.interactive;
                     showDefaultValue = original.showDefaultValue;
@@ -4366,9 +4366,10 @@ public class CommandLine {
     
                 /** Sets the name of the option or positional parameter used in the usage help message, and returns this builder. */
                 public T paramLabel(String paramLabel)       { this.paramLabel = Assert.notNull(paramLabel, "paramLabel"); return self(); }
-    
-                /** Sets the name of the option or positional parameter used in the usage help message, and returns this builder. */
-                public T fixParamLabel(boolean fixParamLabel) { this.fixParamLabel = fixParamLabel; return self(); }
+	
+				/** Indicates whether paramLabel should be processed the regular way or that it should be rendered as-is.
+				 * @see #paramLabel()  {@link #paramLabel()} */
+                public T showParamSyntax(boolean showParamSyntax) { this.showParamSyntax = showParamSyntax; return self(); }
     
                 /** Sets auxiliary type information, and returns this builder.
                  * @param types  the element type(s) when the {@link #type()} is a generic {@code Collection} or a {@code Map};
@@ -7714,7 +7715,7 @@ public class CommandLine {
             public Text renderParameterLabel(ArgSpec argSpec, Ansi ansi, List<IStyle> styles) {
                 Range capacity = argSpec.isOption() ? argSpec.arity() : ((PositionalParamSpec)argSpec).capacity();
                 if (capacity.max == 0) { return ansi.new Text(""); }
-                if (argSpec.fixParamLabel()) { return ansi.apply(" " + argSpec.paramLabel(), styles); }
+                if (!argSpec.showParamSyntax()) { return ansi.apply(separator() + argSpec.paramLabel(), styles); }
                 
                 Text paramName = ansi.apply(argSpec.paramLabel(), styles);
                 String split = argSpec.splitRegex();

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -3914,6 +3914,7 @@ public class CommandLine {
             // help-related fields
             private final boolean hidden;
             private final String paramLabel;
+            private final boolean fixParamLabel;
             private final String[] description;
             private final Help.Visibility showDefaultValue;
 
@@ -3942,6 +3943,7 @@ public class CommandLine {
                 description = builder.description == null ? new String[0] : builder.description;
                 splitRegex = builder.splitRegex == null ? "" : builder.splitRegex;
                 paramLabel = empty(builder.paramLabel) ? "PARAM" : builder.paramLabel;
+                fixParamLabel = builder.fixParamLabel;
                 converters = builder.converters == null ? new ITypeConverter<?>[0] : builder.converters;
                 showDefaultValue = builder.showDefaultValue == null ? Help.Visibility.ON_DEMAND : builder.showDefaultValue;
                 hidden = builder.hidden;
@@ -4044,6 +4046,10 @@ public class CommandLine {
             /** Returns the name of the option or positional parameter used in the usage help message.
              * @see Option#paramLabel() {@link Parameters#paramLabel()} */
             public String paramLabel()     { return paramLabel; }
+    
+            /** Indicates whether paramLabel should be processed the regular way or that it should be rendered as-is.
+             * @see #paramLabel()  {@link #fixParamLabel()} */
+            public boolean fixParamLabel()     { return fixParamLabel; }
     
             /** Returns auxiliary type information used when the {@link #type()} is a generic {@code Collection}, {@code Map} or an abstract class.
              * @see Option#type() */
@@ -4212,6 +4218,7 @@ public class CommandLine {
                 private boolean required;
                 private boolean interactive;
                 private String paramLabel;
+                private boolean fixParamLabel;
                 private String splitRegex;
                 private boolean hidden;
                 private Class<?> type;
@@ -4237,6 +4244,7 @@ public class CommandLine {
                     setter = original.setter;
                     hidden = original.hidden;
                     paramLabel = original.paramLabel;
+                    fixParamLabel = original.fixParamLabel;
                     required = original.required;
                     interactive = original.interactive;
                     showDefaultValue = original.showDefaultValue;
@@ -4331,6 +4339,9 @@ public class CommandLine {
     
                 /** Sets the name of the option or positional parameter used in the usage help message, and returns this builder. */
                 public T paramLabel(String paramLabel)       { this.paramLabel = Assert.notNull(paramLabel, "paramLabel"); return self(); }
+    
+                /** Sets the name of the option or positional parameter used in the usage help message, and returns this builder. */
+                public T fixParamLabel(boolean fixParamLabel) { this.fixParamLabel = fixParamLabel; return self(); }
     
                 /** Sets auxiliary type information, and returns this builder.
                  * @param types  the element type(s) when the {@link #type()} is a generic {@code Collection} or a {@code Map};
@@ -7677,10 +7688,11 @@ public class CommandLine {
             }
             public String separator() { return commandSpec.parser().separator(); }
             public Text renderParameterLabel(ArgSpec argSpec, Ansi ansi, List<IStyle> styles) {
-                Text paramName = ansi.apply(argSpec.paramLabel(), styles);
                 Range capacity = argSpec.isOption() ? argSpec.arity() : ((PositionalParamSpec)argSpec).capacity();
                 if (capacity.max == 0) { return ansi.new Text(""); }
-
+                if (argSpec.fixParamLabel()) { return ansi.apply(" " + argSpec.paramLabel(), styles); }
+                
+                Text paramName = ansi.apply(argSpec.paramLabel(), styles);
                 String split = argSpec.splitRegex();
                 String mandatorySep = empty(split) ? " "  : split;
                 String optionalSep  = empty(split) ? " [" : "[" + split;

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -4218,6 +4218,7 @@ public class CommandLine {
                         && Assert.equals(this.arity, other.arity)
                         && Assert.equals(this.hidden, other.hidden)
                         && Assert.equals(this.paramLabel, other.paramLabel)
+                        && Assert.equals(this.hideParamSyntax, other.hideParamSyntax)
                         && Assert.equals(this.required, other.required)
                         && Assert.equals(this.splitRegex, other.splitRegex)
                         && Arrays.equals(this.description, other.description)
@@ -4232,6 +4233,7 @@ public class CommandLine {
                         + 37 * Assert.hashCode(arity)
                         + 37 * Assert.hashCode(hidden)
                         + 37 * Assert.hashCode(paramLabel)
+                        + 37 * Assert.hashCode(hideParamSyntax)
                         + 37 * Assert.hashCode(required)
                         + 37 * Assert.hashCode(splitRegex)
                         + 37 * Arrays.hashCode(description)
@@ -4297,10 +4299,14 @@ public class CommandLine {
                 /** Returns how many arguments this option or positional parameter requires.
                  * @see Option#arity() */
                 public Range arity()           { return arity; }
-
+    
                 /** Returns the name of the option or positional parameter used in the usage help message.
                  * @see Option#paramLabel() {@link Parameters#paramLabel()} */
                 public String paramLabel()     { return paramLabel; }
+    
+                /** Indicates whether paramLabel should be processed the regular way or that it should be rendered as-is.
+                 * @see #paramLabel()  {@link #paramLabel()} */
+                public boolean hideParamSyntax()     { return hideParamSyntax; }
 
                 /** Returns auxiliary type information used when the {@link #type()} is a generic {@code Collection}, {@code Map} or an abstract class.
                  * @see Option#type() */

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -3941,7 +3941,7 @@ public class CommandLine {
             // help-related fields
             private final boolean hidden;
             private final String paramLabel;
-            private final boolean showParamSyntax;
+            private final boolean hideParamSyntax;
             private final String[] description;
             private final Help.Visibility showDefaultValue;
 
@@ -3970,7 +3970,7 @@ public class CommandLine {
                 description = builder.description == null ? new String[0] : builder.description;
                 splitRegex = builder.splitRegex == null ? "" : builder.splitRegex;
                 paramLabel = empty(builder.paramLabel) ? "PARAM" : builder.paramLabel;
-                showParamSyntax = builder.showParamSyntax;
+                hideParamSyntax = builder.hideParamSyntax;
                 converters = builder.converters == null ? new ITypeConverter<?>[0] : builder.converters;
                 showDefaultValue = builder.showDefaultValue == null ? Help.Visibility.ON_DEMAND : builder.showDefaultValue;
                 hidden = builder.hidden;
@@ -4076,7 +4076,7 @@ public class CommandLine {
     
             /** Indicates whether paramLabel should be processed the regular way or that it should be rendered as-is.
              * @see #paramLabel()  {@link #paramLabel()} */
-            public boolean showParamSyntax()     { return showParamSyntax; }
+            public boolean hideParamSyntax()     { return hideParamSyntax; }
     
             /** Returns auxiliary type information used when the {@link #type()} is a generic {@code Collection}, {@code Map} or an abstract class.
              * @see Option#type() */
@@ -4245,7 +4245,7 @@ public class CommandLine {
                 private boolean required;
                 private boolean interactive;
                 private String paramLabel;
-                private boolean showParamSyntax = true;
+                private boolean hideParamSyntax;
                 private String splitRegex;
                 private boolean hidden;
                 private Class<?> type;
@@ -4271,7 +4271,7 @@ public class CommandLine {
                     setter = original.setter;
                     hidden = original.hidden;
                     paramLabel = original.paramLabel;
-                    showParamSyntax = original.showParamSyntax;
+                    hideParamSyntax = original.hideParamSyntax;
                     required = original.required;
                     interactive = original.interactive;
                     showDefaultValue = original.showDefaultValue;
@@ -4369,7 +4369,7 @@ public class CommandLine {
 	
 				/** Indicates whether paramLabel should be processed the regular way or that it should be rendered as-is.
 				 * @see #paramLabel()  {@link #paramLabel()} */
-                public T showParamSyntax(boolean showParamSyntax) { this.showParamSyntax = showParamSyntax; return self(); }
+                public T hideParamSyntax(boolean hideParamSyntax) { this.hideParamSyntax = hideParamSyntax; return self(); }
     
                 /** Sets auxiliary type information, and returns this builder.
                  * @param types  the element type(s) when the {@link #type()} is a generic {@code Collection} or a {@code Map};
@@ -7715,7 +7715,7 @@ public class CommandLine {
             public Text renderParameterLabel(ArgSpec argSpec, Ansi ansi, List<IStyle> styles) {
                 Range capacity = argSpec.isOption() ? argSpec.arity() : ((PositionalParamSpec)argSpec).capacity();
                 if (capacity.max == 0) { return ansi.new Text(""); }
-                if (!argSpec.showParamSyntax()) { return ansi.apply(separator() + argSpec.paramLabel(), styles); }
+                if (argSpec.hideParamSyntax()) { return ansi.apply(separator() + argSpec.paramLabel(), styles); }
                 
                 Text paramName = ansi.apply(argSpec.paramLabel(), styles);
                 String split = argSpec.splitRegex();

--- a/src/test/java/picocli/CommandLineModelTest.java
+++ b/src/test/java/picocli/CommandLineModelTest.java
@@ -59,19 +59,37 @@ public class CommandLineModelTest {
         commandLine.parse("-p", "123", "abc");
         assertEquals(Arrays.asList("-p", "123", "abc"), commandLine.getUnmatchedArguments());
     }
-
+    
     @Test
     public void testModelUsageHelp() throws Exception {
         CommandSpec spec = CommandSpec.create();
         spec.addOption(OptionSpec.builder("-h", "--help").usageHelp(true).description("show help and exit").build());
         spec.addOption(OptionSpec.builder("-V", "--version").versionHelp(true).description("show help and exit").build());
         spec.addOption(OptionSpec.builder("-c", "--count").paramLabel("COUNT").arity("1").type(int.class).description("number of times to execute").build());
-        spec.addOption(OptionSpec.builder("-f", "--fix").paramLabel("FIXED(=BOOLEAN)").arity("1").fixParamLabel(true).required(true).description("run with fixed option").build());
+        spec.addOption(OptionSpec.builder("-f", "--fix").paramLabel("FIXED(BOOLEAN)").arity("1").showParamSyntax(false).required(true).description("run with fixed option").build());
         CommandLine commandLine = new CommandLine(spec);
         String actual = usageString(commandLine, Ansi.OFF);
         String expected = String.format("" +
-                "Usage: <main class> [-hV] [-c=COUNT] -f FIXED(=BOOLEAN)%n" +
-                "  -c, --count=COUNT   number of times to execute%n" +
+                "Usage: <main class> [-hV] [-c=COUNT] -f=FIXED(BOOLEAN)%n" +
+                "  -c, --count=COUNT          number of times to execute%n" +
+                "  -f, --fix=FIXED(BOOLEAN)   run with fixed option%n" +
+                "  -h, --help                 show help and exit%n" +
+                "  -V, --version              show help and exit%n");
+        assertEquals(expected, actual);
+    }
+    
+    @Test
+    public void testModelUsageHelpWithCustomSeparator() throws Exception {
+        CommandSpec spec = CommandSpec.create();
+        spec.addOption(OptionSpec.builder("-h", "--help").usageHelp(true).description("show help and exit").build());
+        spec.addOption(OptionSpec.builder("-V", "--version").versionHelp(true).description("show help and exit").build());
+        spec.addOption(OptionSpec.builder("-c", "--count").paramLabel("COUNT").arity("1").type(int.class).description("number of times to execute").build());
+        spec.addOption(OptionSpec.builder("-f", "--fix").paramLabel("FIXED(=BOOLEAN)").arity("1").showParamSyntax(false).required(true).description("run with fixed option").build());
+        CommandLine commandLine = new CommandLine(spec).setSeparator(" ");
+        String actual = usageString(commandLine, Ansi.OFF);
+        String expected = String.format("" +
+                "Usage: <main class> [-hV] [-c COUNT] -f FIXED(=BOOLEAN)%n" +
+                "  -c, --count COUNT   number of times to execute%n" +
                 "  -f, --fix FIXED(=BOOLEAN)%n" +
                 "                      run with fixed option%n" +
                 "  -h, --help          show help and exit%n" +
@@ -499,7 +517,7 @@ public class CommandLineModelTest {
     }
     @Test
     public void testPositionalDefaultFixParamLabelIsFalse() throws Exception {
-        assertFalse(PositionalParamSpec.builder().build().fixParamLabel());
+        assertTrue(PositionalParamSpec.builder().build().showParamSyntax());
     }
 
     @Test

--- a/src/test/java/picocli/CommandLineModelTest.java
+++ b/src/test/java/picocli/CommandLineModelTest.java
@@ -66,7 +66,7 @@ public class CommandLineModelTest {
         spec.addOption(OptionSpec.builder("-h", "--help").usageHelp(true).description("show help and exit").build());
         spec.addOption(OptionSpec.builder("-V", "--version").versionHelp(true).description("show help and exit").build());
         spec.addOption(OptionSpec.builder("-c", "--count").paramLabel("COUNT").arity("1").type(int.class).description("number of times to execute").build());
-        spec.addOption(OptionSpec.builder("-f", "--fix").paramLabel("FIXED(BOOLEAN)").arity("1").showParamSyntax(false).required(true).description("run with fixed option").build());
+        spec.addOption(OptionSpec.builder("-f", "--fix").paramLabel("FIXED(BOOLEAN)").arity("1").hideParamSyntax(true).required(true).description("run with fixed option").build());
         CommandLine commandLine = new CommandLine(spec);
         String actual = usageString(commandLine, Ansi.OFF);
         String expected = String.format("" +
@@ -84,7 +84,7 @@ public class CommandLineModelTest {
         spec.addOption(OptionSpec.builder("-h", "--help").usageHelp(true).description("show help and exit").build());
         spec.addOption(OptionSpec.builder("-V", "--version").versionHelp(true).description("show help and exit").build());
         spec.addOption(OptionSpec.builder("-c", "--count").paramLabel("COUNT").arity("1").type(int.class).description("number of times to execute").build());
-        spec.addOption(OptionSpec.builder("-f", "--fix").paramLabel("FIXED(=BOOLEAN)").arity("1").showParamSyntax(false).required(true).description("run with fixed option").build());
+        spec.addOption(OptionSpec.builder("-f", "--fix").paramLabel("FIXED(=BOOLEAN)").arity("1").hideParamSyntax(true).required(true).description("run with fixed option").build());
         CommandLine commandLine = new CommandLine(spec).setSeparator(" ");
         String actual = usageString(commandLine, Ansi.OFF);
         String expected = String.format("" +
@@ -517,7 +517,7 @@ public class CommandLineModelTest {
     }
     @Test
     public void testPositionalDefaultFixParamLabelIsFalse() throws Exception {
-        assertTrue(PositionalParamSpec.builder().build().showParamSyntax());
+        assertTrue(PositionalParamSpec.builder().build().hideParamSyntax());
     }
 
     @Test

--- a/src/test/java/picocli/CommandLineModelTest.java
+++ b/src/test/java/picocli/CommandLineModelTest.java
@@ -66,11 +66,14 @@ public class CommandLineModelTest {
         spec.addOption(OptionSpec.builder("-h", "--help").usageHelp(true).description("show help and exit").build());
         spec.addOption(OptionSpec.builder("-V", "--version").versionHelp(true).description("show help and exit").build());
         spec.addOption(OptionSpec.builder("-c", "--count").paramLabel("COUNT").arity("1").type(int.class).description("number of times to execute").build());
+        spec.addOption(OptionSpec.builder("-f", "--fix").paramLabel("FIXED(=BOOLEAN)").arity("1").fixParamLabel(true).required(true).description("run with fixed option").build());
         CommandLine commandLine = new CommandLine(spec);
         String actual = usageString(commandLine, Ansi.OFF);
         String expected = String.format("" +
-                "Usage: <main class> [-hV] [-c=COUNT]%n" +
+                "Usage: <main class> [-hV] [-c=COUNT] -f FIXED(=BOOLEAN)%n" +
                 "  -c, --count=COUNT   number of times to execute%n" +
+                "  -f, --fix FIXED(=BOOLEAN)%n" +
+                "                      run with fixed option%n" +
                 "  -h, --help          show help and exit%n" +
                 "  -V, --version       show help and exit%n");
         assertEquals(expected, actual);
@@ -493,6 +496,10 @@ public class CommandLineModelTest {
     @Test
     public void testPositionalDefaultRequiredIsFalse() throws Exception {
         assertFalse(PositionalParamSpec.builder().build().required());
+    }
+    @Test
+    public void testPositionalDefaultFixParamLabelIsFalse() throws Exception {
+        assertFalse(PositionalParamSpec.builder().build().fixParamLabel());
     }
 
     @Test

--- a/src/test/java/picocli/CommandLineModelTest.java
+++ b/src/test/java/picocli/CommandLineModelTest.java
@@ -517,7 +517,7 @@ public class CommandLineModelTest {
     }
     @Test
     public void testPositionalDefaultFixParamLabelIsFalse() throws Exception {
-        assertTrue(PositionalParamSpec.builder().build().hideParamSyntax());
+        assertFalse(PositionalParamSpec.builder().build().hideParamSyntax());
     }
 
     @Test


### PR DESCRIPTION
Here's a simple fix that allows users to choose to omit regular paramLabel processing and fix it to render as-is instead (ANSI codes notwithstanding).