### PR TITLE
321 add support for default value provider

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -5394,6 +5394,7 @@ public class CommandLine {
                 commandSpec.initVersion(cmd.version());
                 commandSpec.initHelpCommand(cmd.helpCommand());
                 commandSpec.initVersionProvider(cmd.versionProvider(), factory);
+                commandSpec.initDefaultValueProvider(cmd.defaultValueProvider(), factory);
                 UsageMessageSpec usageMessage = commandSpec.usageMessage();
                 usageMessage.initSynopsisHeading(cmd.synopsisHeading());
                 usageMessage.initCommandListHeading(cmd.commandListHeading());
@@ -6237,7 +6238,12 @@ public class CommandLine {
         private void applyDefault(IDefaultValueProvider defaultValueProvider,
             ArgSpec arg, List<ArgSpec> required) throws Exception {
 
-            String defaultValue = defaultValueProvider == null ? arg.defaultValue() : defaultValueProvider.defaultValue(arg) ;
+            boolean isDefaultOrInitialVaLuePresent = arg.defaultValue() != null || arg.initialValue() != null;
+
+            // Default value provider is only used if the argSpec doesn't already have a default
+            // value or an initial value
+            String defaultValue = defaultValueProvider != null && !isDefaultOrInitialVaLuePresent ?
+                    defaultValueProvider.defaultValue(arg) : arg.defaultValue() ;
 
             if (defaultValue == null) { return; }
             if (tracer.isDebug()) {tracer.debug("Applying defaultValue (%s) to %s%n", defaultValue, arg);}

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -6036,18 +6036,24 @@ public class CommandLine {
 
         private void applyDefaultValues(List<ArgSpec> required) throws Exception {
             parseResult.isInitializingDefaultValues = true;
-            for (OptionSpec option              : commandSpec.options())              { applyDefault(option,     required); }
-            for (PositionalParamSpec positional : commandSpec.positionalParameters()) { applyDefault(positional, required); }
+            for (OptionSpec option              : commandSpec.options())              { applyDefault(commandSpec.defaultValueProvider, option,     required); }
+            for (PositionalParamSpec positional : commandSpec.positionalParameters()) { applyDefault(commandSpec.defaultValueProvider, positional, required); }
             parseResult.isInitializingDefaultValues = false;
         }
 
-        private void applyDefault(ArgSpec arg, List<ArgSpec> required) throws Exception {
-            if (arg.defaultValue() == null) { return; }
-            if (tracer.isDebug()) {tracer.debug("Applying defaultValue (%s) to %s%n", arg.defaultValue(), arg);}
+        private void applyDefault(IDefaultValueProvider defaultValueProvider,
+            ArgSpec arg, List<ArgSpec> required) throws Exception {
+
+            String defaultValue = defaultValueProvider == null ? arg.defaultValue() : defaultValueProvider.defaultValue(arg) ;
+
+            if (defaultValue == null) { return; }
+            if (tracer.isDebug()) {tracer.debug("Applying defaultValue (%s) to %s%n", defaultValue, arg);}
             Range arity = arg.arity().min(Math.max(1, arg.arity().min));
-            applyOption(arg, LookBehind.SEPARATE, arity, stack(arg.defaultValue()), new HashSet<ArgSpec>(), arg.toString);
+
+            applyOption(arg, LookBehind.SEPARATE, arity, stack(defaultValue), new HashSet<ArgSpec>(), arg.toString);
             required.remove(arg);
         }
+
         private Stack<String> stack(String value) {Stack<String> result = new Stack<String>(); result.push(value); return result;}
 
         private void processArguments(List<CommandLine> parsedCommands,

--- a/src/test/java/picocli/CommandLineDefaultProviderTest.java
+++ b/src/test/java/picocli/CommandLineDefaultProviderTest.java
@@ -1,0 +1,82 @@
+package picocli;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.IDefaultValueProvider;
+import picocli.CommandLine.Model.ArgSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+public class CommandLineDefaultProviderTest {
+
+  static class TestDefaultProvider implements IDefaultValueProvider {
+    public String defaultValue(ArgSpec argSpec) {
+      return "Default provider string value";
+    }
+  }
+
+  @Command(defaultValueProvider = TestDefaultProvider.class)
+  static class App {
+    @Option(names = "-a")
+    private String optionStringFieldWithoutDefaultNorInitialValue;
+    @Option(names = "-b", defaultValue = "Annotated default value")
+    private String optionStringFieldWithAnnotatedDefault;
+    @Option(names = "-c")
+    private String optionStringFieldWithInitDefault = "Initial default value";
+
+    @Parameters(arity = "0..1")
+    private String paramStringFieldWithoutDefaultNorInitialValue;
+    @Parameters(arity = "0..1", defaultValue = "Annotated default value")
+    private String paramStringFieldWithAnnotatedDefault;
+    @Parameters(arity = "0..1")
+    private String paramStringFieldWithInitDefault = "Initial default value";
+
+    private String stringForSetterDefault;
+    @Option(names = "-d", defaultValue = "Annotated setter default value")
+    void setString(String val) { stringForSetterDefault = val; }
+  }
+
+
+  @Test
+  public void testCommandDefaultProviderByAnnotation() {
+
+    CommandLine cmd = new CommandLine(App.class);
+    cmd.parse();
+
+    App app = cmd.getCommand();
+    // if no default defined on the option, command default provider should be used
+    assertEquals("Default provider string value",app.optionStringFieldWithoutDefaultNorInitialValue);
+    assertEquals("Default provider string value",app.paramStringFieldWithoutDefaultNorInitialValue);
+    // if a default is defined on the option either by annotation or by initial value, it must
+    // override the default provider.
+    assertEquals("Annotated default value",app.optionStringFieldWithAnnotatedDefault);
+    assertEquals("Annotated default value",app.paramStringFieldWithAnnotatedDefault);
+
+    assertEquals("Initial default value",app.optionStringFieldWithInitDefault);
+    assertEquals("Initial default value",app.paramStringFieldWithInitDefault);
+
+    assertEquals("Annotated setter default value",app.stringForSetterDefault);
+
+  }
+
+  static class AppWithoutAnnotation {
+    @Option(names = "-a")
+    private String stringFieldWithoutDefaultNorInitialValue;
+  }
+
+  @Test
+  public void testCommandDefaultProviderSetting() {
+
+    CommandLine cmd = new CommandLine(App.class);
+    cmd.setDefaultValueProvider(new TestDefaultProvider());
+    cmd.parse();
+
+    App app = cmd.getCommand();
+    // if no default defined on the option, command default provider should be used
+    assertEquals("Default provider string value",app.optionStringFieldWithoutDefaultNorInitialValue);
+  }
+}


### PR DESCRIPTION
Adding support for a default value provider that could enable me to have those defaults loaded from a configuration file.

See issue #321 