### PR TITLE
Fix doc link for moved example files

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1296,9 +1296,9 @@ public interface IVersionProvider {
 Version providers declared with the `versionProvider` attribute need to have a public no-argument constructor to be instantiated, unless a <<Custom Factory>> is installed to instantiate classes.
 
 The GitHub project has a manifest file-based
-https://github.com/remkop/picocli/blob/master/examples/src/main/java/picocli/examples/VersionProviderDemo2.java[example]
+https://github.com/remkop/picocli/blob/master/picocli-examples/src/main/java/picocli/examples/VersionProviderDemo2.java[example]
 and a build-generated version properties file-based
-https://github.com/remkop/picocli/blob/master/examples/src/main/java/picocli/examples/VersionProviderDemo1.java[example] version provider implementation.
+https://github.com/remkop/picocli/blob/master/picocli-examples/src/main/java/picocli/examples/VersionProviderDemo1.java[example] version provider implementation.
 
 == Usage Help
 === Compact Example

--- a/docs/quick-guide.adoc
+++ b/docs/quick-guide.adoc
@@ -378,9 +378,9 @@ and invoke it to collect version information.
 
 
 The GitHub project has an
-https://github.com/remkop/picocli/blob/master/examples/src/main/java/picocli/examples/VersionProviderDemo2.java[example]
+https://github.com/remkop/picocli/blob/master/picocli-examples/src/main/java/picocli/examples/VersionProviderDemo2.java[example]
 implementation that gets the version from the manifest file and another
-https://github.com/remkop/picocli/blob/master/examples/src/main/java/picocli/examples/VersionProviderDemo1.java[example]
+https://github.com/remkop/picocli/blob/master/picocli-examples/src/main/java/picocli/examples/VersionProviderDemo1.java[example]
 that gets version information from a build-generated version properties file.
 
 == Usage Help


### PR DESCRIPTION
Noticed there were a couple of broken links on the website because the example files directory has been renamed.