### PR TITLE
Fill array values before setting them as value

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -7227,10 +7227,10 @@ public class CommandLine {
                 }
             }
             Object array = Array.newInstance(type, newValues.size());
-            argSpec.setValue(array, commandSpec.commandLine());
             for (int i = 0; i < newValues.size(); i++) {
                 Array.set(array, i, newValues.get(i));
             }
+            argSpec.setValue(array, commandSpec.commandLine());
             parseResult.add(argSpec, position);
             return converted.size(); // return how many args were consumed
         }

--- a/src/test/java/picocli/CommandLineTest.java
+++ b/src/test/java/picocli/CommandLineTest.java
@@ -195,6 +195,38 @@ public class CommandLineTest {
         assertNotSame(array, params.array);
         assertArrayEquals(new int[]{3, 2, 1}, params.array);
     }
+    @Test
+    public void testArrayPositionalParametersAreFilledWithValues() {
+        @Command
+        class ArrayPositionalParams {
+            String string;
+            @Parameters()
+            void setString( String[] array) {
+                StringBuilder sb = new StringBuilder();
+                for (String s : array) { sb.append(s); }
+                string = sb.toString();
+            }
+        }
+        ArrayPositionalParams params = new ArrayPositionalParams();
+        new CommandLine(params).parse("foo", "bar", "baz");
+        assertEquals("foobarbaz", params.string);
+    }
+    @Test
+    public void testArrayOptionsAreFilledWithValues() {
+        @Command
+        class ArrayPositionalParams {
+            String string;
+            @Option(names="-s")
+            void setString( String[] array) {
+                StringBuilder sb = new StringBuilder();
+                for (String s : array) { sb.append(s); }
+                string = sb.toString();
+            }
+        }
+        ArrayPositionalParams params = new ArrayPositionalParams();
+        new CommandLine(params).parse("-s", "foo", "-s", "bar", "-s", "baz");
+        assertEquals("foobarbaz", params.string);
+    }
     private class ListPositionalParams {
         @Parameters(type = Integer.class) List<Integer> list;
     }


### PR DESCRIPTION
When using setter methods for array options, the values aren't set when the setter is invoked, making it impossible to do any kind of processing on the values other than storing the array, as every value is null.