### PR TITLE
Allow @Mixin to be used for methods as well

### DIFF
--- a/src/test/java/picocli/CommandLineMixinTest.java
+++ b/src/test/java/picocli/CommandLineMixinTest.java
@@ -93,6 +93,20 @@ public class CommandLineMixinTest {
     }
 
     @Test
+    public void testAddMixinMustBeValidCommand_SubCommandMethod() {
+        @Command class ValidMixin {  // valid command because it has @Command annotation
+        }
+        @Command class Receiver {
+            @Command void sub(@Mixin ValidMixin mixin) {
+            }
+        }
+        CommandLine commandLine = new CommandLine(new Receiver(), new InnerClassFactory(this));
+        CommandSpec commandSpec = commandLine.getCommandSpec().subcommands().get("sub").getCommandSpec().mixins().get("arg0");
+        assertEquals(ValidMixin.class, commandSpec.userObject().getClass());
+        commandLine.addMixin("valid", new ValidMixin()); // no exception
+    }
+
+    @Test
     public void testMixinAnnotationRejectedIfNotAValidCommand() {
         class Invalid {}
         class Receiver {


### PR DESCRIPTION
This one allows Mixins to be used as method parameters, in particular for subcommands that are defined as methods.