### PR TITLE
Add a way to get the argument attempted to be overwritten from an OverwrittenOptionException

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -7104,7 +7104,7 @@ public class CommandLine {
             if (initialized != null) {
                 if (initialized.contains(argSpec)) {
                     if (!isOverwrittenOptionsAllowed()) {
-                        throw new OverwrittenOptionException(CommandLine.this, optionDescription("", argSpec, 0) +  " should be specified only once");
+                        throw new OverwrittenOptionException(CommandLine.this, argSpec, optionDescription("", argSpec, 0) +  " should be specified only once");
                     }
                     traceMessage = "Overwriting %s value '%s' with '%s' for %s%n";
                 }
@@ -10117,7 +10117,13 @@ public class CommandLine {
     /** Exception indicating that an option for a single-value option field has been specified multiple times on the command line. */
     public static class OverwrittenOptionException extends ParameterException {
         private static final long serialVersionUID = 1338029208271055776L;
-        public OverwrittenOptionException(CommandLine commandLine, String msg) { super(commandLine, msg); }
+        private final ArgSpec overwrittenArg;
+        public OverwrittenOptionException(CommandLine commandLine, ArgSpec overwritten, String msg) {
+        	super(commandLine, msg);
+        	overwrittenArg = overwritten;
+        }
+        /** Returns the {@link ArgSpec} for the option which was being overwritten. */
+        public ArgSpec getOverwritten() { return overwrittenArg; }
     }
     /**
      * Exception indicating that an annotated field had a type for which no {@link ITypeConverter} was

--- a/src/test/java/picocli/CommandLineTest.java
+++ b/src/test/java/picocli/CommandLineTest.java
@@ -2568,6 +2568,26 @@ public class CommandLineTest {
     }
 
     @Test
+    public void testOverwrittenOptionExceptionContainsCorrectArgSpec() {
+        class App {
+            @Option(names = "-s") String string;
+            @Option(names = "-v") boolean bool;
+        }
+        try {
+            CommandLine.populateCommand(new App(), "-s", "1", "-s", "2");
+            fail("expected exception");
+        } catch (OverwrittenOptionException ex) {
+            assertEquals(ex.getCommandLine().getCommandSpec().optionsMap().get("-s"), ex.getOverwritten());
+        }
+        try {
+            CommandLine.populateCommand(new App(), "-v", "-v");
+            fail("expected exception");
+        } catch (OverwrittenOptionException ex) {
+            assertEquals(ex.getCommandLine().getCommandSpec().optionsMap().get("-v"), ex.getOverwritten());
+        }
+    }
+
+    @Test
     public void testOverwrittenOptionSetsLastValueIfAllowed() {
         class App {
             @Option(names = {"-s", "--str"})      String string;


### PR DESCRIPTION
Provides a nice way to get the `ArgSpec` of the option which was being overwritten before throwing an `OverwrittenOptionException`. The `ArgSpec` is retrieved through `OverwrittenOptionException#getOverwritten()`, which can be taken advantage of in a custom `IExceptionHandler2` to automate exception handling, generate custom error messages, etc.

I was in the process of writing a custom `IExceptionHandler2` and noticed some `ParameterException`s have convenience methods for accessing the root of the exception (see `MissingParameterException#getMissing()`) and thought `OverwrittenOptionException` was missing such a method. It's a tiny pr, but seems useful to me at least. Thanks for the consideration.