### PR TITLE
Print help infinite loop fix

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -9240,7 +9240,7 @@ public class CommandLine {
                         break;
                     }
                 }
-                if (done == 0 && length(text) > columnValue.maxLength) {
+                if (done == 0 && length(text) + offset > columnValue.maxLength) {
                     // The value is a single word that is too big to be written to the column. Write as much as we can.
                     done = copy(text, columnValue, offset);
                 }

--- a/src/test/java/picocli/CommandLineHelpTest.java
+++ b/src/test/java/picocli/CommandLineHelpTest.java
@@ -3845,7 +3845,6 @@ public class CommandLineHelpTest {
                 "                 Default:%n" +
                 "                 /long/value/length/equals/columnValue/maxlength/and/non/null/offset/%n" +
                 "                 xxx%n");
-        //CommandLine.usage(new Args(), System.out);
         assertEquals(expected, usageString(new Args(), Help.Ansi.OFF));
     }
 

--- a/src/test/java/picocli/CommandLineHelpTest.java
+++ b/src/test/java/picocli/CommandLineHelpTest.java
@@ -3833,6 +3833,22 @@ public class CommandLineHelpTest {
                 "  -V, --version   Print version information and exit.%n"), new CommandLine(multiLineCmd).getUsageMessage());
     }
 
+    @Test
+    public void testMultiLineWrappedDefaultValueWontRunIntoInfiniteLoop(){
+        class Args {
+            @Parameters(arity = "1..*", description = "description", defaultValue = "/long/value/length/equals/columnValue/maxlength/and/non/null/offset/xxx", showDefaultValue = ALWAYS)
+            String[] c;
+        }
+        String expected = String.format("" +
+                "Usage: <main class> <c>...%n" +
+                "      <c>...   description%n" +
+                "                 Default:%n" +
+                "                 /long/value/length/equals/columnValue/maxlength/and/non/null/offset/%n" +
+                "                 xxx%n");
+        //CommandLine.usage(new Args(), System.out);
+        assertEquals(expected, usageString(new Args(), Help.Ansi.OFF));
+    }
+
     private static CommandSpec createCmd(String name, String description) {
         CommandSpec cmd = CommandSpec.create().name(name).mixinStandardHelpOptions(true);
         cmd.usageMessage().description(description);


### PR DESCRIPTION
Print help run into infinite loop when length of the text equals to `columnValue.maxLength` and offset is non zero.