### PR TITLE
Allow for enabling quote trimming via a system property

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -426,16 +426,21 @@ public class CommandLine {
         return this;
     }
 
-    /** Returns whether the parser should trim quotes from command line arguments before processing them. The default is {@code false}.
+    /** Returns whether the parser should trim quotes from command line arguments before processing them. The default is
+     * read from the system property "picocli.trimQuotes" and will be {@code true} if the property is present and empty,
+     * or if its value is "true".
      * @return {@code true} if the parser should trim quotes from command line arguments before processing them, {@code false} otherwise;
      * @since 3.7 */
     public boolean isTrimQuotes() { return getCommandSpec().parser().trimQuotes(); }
 
-    /** Sets whether the parser should trim quotes from command line arguments before processing them. The default is {@code false}.
+    /** Sets whether the parser should trim quotes from command line arguments before processing them. The default is
+     * read from the system property "picocli.trimQuotes" and will be {@code true} if the property is set and empty, or
+     * if its value is "true".
      * <p>The specified setting will be registered with this {@code CommandLine} and the full hierarchy of its
      * subcommands and nested sub-subcommands <em>at the moment this method is called</em>. Subcommands added
      * later will have the default setting. To ensure a setting is applied to all
      * subcommands, call the setter last, after adding subcommands.</p>
+     * <p>Calling this method will cause the "picocli.trimQuotes" property to have no effect.</p>
      * @param newValue the new setting
      * @return this {@code CommandLine} object, to allow method chaining
      * @since 3.7
@@ -4427,7 +4432,7 @@ public class CommandLine {
             private boolean aritySatisfiedByAttachedOptionParam = false;
             private boolean collectErrors = false;
             private boolean caseInsensitiveEnumValuesAllowed = false;
-            private boolean trimQuotes = false;
+            private boolean trimQuotes = shouldTrimQuotes();
             private boolean splitQuotedStrings = false;
 
             /** Returns the String to use as the separator between options and option parameters. {@code "="} by default,
@@ -4521,6 +4526,13 @@ public class CommandLine {
             /** Sets whether arguments should be {@linkplain ArgSpec#splitRegex() split} first before any further processing.
              * If true, the original argument will only be split into as many parts as allowed by max arity. */
             public ParserSpec limitSplit(boolean limitSplit)                               { this.limitSplit = limitSplit; return this; }
+
+            private boolean shouldTrimQuotes() {
+                String value = System.getProperty("picocli.trimQuotes");
+                if ("".equals(value)) { value = "true"; }
+                return Boolean.valueOf(value);
+            }
+
             void initSeparator(String value)   { if (initializable(separator, value, DEFAULT_SEPARATOR)) {separator = value;} }
             void updateSeparator(String value) { if (isNonDefault(value, DEFAULT_SEPARATOR))             {separator = value;} }
             public String toString() {

--- a/src/test/java/picocli/CommandLineTest.java
+++ b/src/test/java/picocli/CommandLineTest.java
@@ -855,6 +855,30 @@ public class CommandLineTest {
     }
 
     @Test
+    public void testTrimQuotesWhenPropertyTrue() {
+        System.setProperty("picocli.trimQuotes", "true");
+        @Command class TopLevel {}
+        CommandLine commandLine = new CommandLine(new TopLevel());
+        assertEquals(true, commandLine.isTrimQuotes());
+    }
+
+    @Test
+    public void testTrimQuotesWhenPropertyEmpty() {
+        System.setProperty("picocli.trimQuotes", "");
+        @Command class TopLevel {}
+        CommandLine commandLine = new CommandLine(new TopLevel());
+        assertEquals(true, commandLine.isTrimQuotes());
+    }
+
+    @Test
+    public void testTrimQuotesWhenPropertyFalse() {
+        System.setProperty("picocli.trimQuotes", "false");
+        @Command class TopLevel {}
+        CommandLine commandLine = new CommandLine(new TopLevel());
+        assertEquals(false, commandLine.isTrimQuotes());
+    }
+
+    @Test
     public void testParserTrimQuotes_BeforeSubcommandsAdded() {
         @Command class TopLevel {}
         CommandLine commandLine = new CommandLine(new TopLevel());
@@ -3678,6 +3702,7 @@ public class CommandLineTest {
     @Test
     public void testAtFileSimplifiedWithQuotesTrimmed() {
         System.setProperty("picocli.useSimplifiedAtFiles", "true");
+        System.setProperty("picocli.trimQuotes", "true");
         class App {
             @Option(names = "--quotedArg")
             private String quoted;
@@ -3689,10 +3714,7 @@ public class CommandLineTest {
             private String unescaped;
         }
         File file = findFile("/argfile-simplified-quoted.txt");
-        final App app = new App();
-        final CommandLine cli = new CommandLine(app);
-        cli.setTrimQuotes(true);
-        cli.parse("@" + file.getAbsolutePath());
+        App app = CommandLine.populateCommand(new App(), "@" + file.getAbsolutePath());
         assertEquals("something else", app.quoted);
         assertEquals("https://picocli.info/", app.url.toString());
         assertEquals("C:\\Program Files\\picocli.txt", app.unescaped);


### PR DESCRIPTION
The property is `picocli.trimQuotes`.

When set to `true` or when left empty, quote trimming will be enabled by default. Otherwise, the default is `false`. Regardless of the value of the property, the value can still be overriden through the usual API - therefore there is no break in backwards compatibility.