### PR TITLE
[#530] Usage message customization (2)

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -8109,6 +8109,7 @@ public class CommandLine {
         private final ColorScheme colorScheme;
         private final Map<String, Help> commands = new LinkedHashMap<String, Help>();
         private List<String> aliases = Collections.emptyList();
+        private IHelpFactory helpFactory;
 
         private IParamLabelRenderer parameterLabelRenderer;
 
@@ -8144,7 +8145,8 @@ public class CommandLine {
             this.aliases.add(0, commandSpec.name());
             this.colorScheme = Assert.notNull(colorScheme, "colorScheme").applySystemProperties();
             parameterLabelRenderer = createDefaultParamLabelRenderer(); // uses help separator
-
+            this.helpFactory = commandSpec.commandLine() != null ? commandSpec.commandLine().getHelpFactory() : new DefaultHelpFactory();
+            
             this.addAllSubcommands(commandSpec.subcommands());
         }
 
@@ -8157,6 +8159,10 @@ public class CommandLine {
         /** Returns the {@code ColorScheme} model that this Help was constructed with.
          * @since 3.0 */
         public ColorScheme colorScheme() { return colorScheme; }
+        
+        /** Returns the {@code ColorScheme} model that this Help was constructed with.
+         * @since 2.9 */
+        private IHelpFactory getHelpFactory() { return helpFactory; }
 
         /** Option and positional parameter value label renderer used for the synopsis line(s) and the option list.
          * By default initialized to the result of {@link #createDefaultParamLabelRenderer()}, which takes a snapshot
@@ -8205,7 +8211,7 @@ public class CommandLine {
          * @return this Help instance (for method chaining) */
         Help addSubcommand(List<String> commandNames, CommandLine commandLine) {
             String all = commandNames.toString();
-            commands.put(all.substring(1, all.length() - 1), new Help(commandLine.commandSpec, colorScheme).withCommandNames(commandNames));
+            commands.put(all.substring(1, all.length() - 1), getHelpFactory().create(commandLine.commandSpec, colorScheme).withCommandNames(commandNames));
             return this;
         }
 
@@ -8216,7 +8222,8 @@ public class CommandLine {
          * @deprecated
          */
         @Deprecated public Help addSubcommand(String commandName, Object command) {
-            commands.put(commandName, new Help(CommandSpec.forAnnotatedObject(command, commandSpec.commandLine().factory)));
+            commands.put(commandName, 
+                    getHelpFactory().create(CommandSpec.forAnnotatedObject(command, commandSpec.commandLine().factory), defaultColorScheme(Ansi.AUTO)));
             return this;
         }
 

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -147,6 +147,7 @@ public class CommandLine {
     private final CommandSpec commandSpec;
     private final Interpreter interpreter;
     private final IFactory factory;
+    private IHelpFactory helpFactory;
 
     /**
      * Constructs a new {@code CommandLine} interpreter with the specified object (which may be an annotated user object or a {@link CommandSpec CommandSpec}) and a default subcommand factory.
@@ -1467,6 +1468,18 @@ public class CommandLine {
      * @since 3.0 */
     public void usage(PrintWriter writer, Help.Ansi ansi) { usage(writer, Help.defaultColorScheme(ansi)); }
 
+    public CommandLine setHelpFactory(IHelpFactory helpFactory) {
+        this.helpFactory = helpFactory;
+        return this;
+    }
+
+    public IHelpFactory getHelpFactory() {
+        if (helpFactory == null) {
+            helpFactory = new DefaultHelpFactory();
+        }
+        return helpFactory;
+    }
+
     /**
      * Prints a usage help message for the annotated command class to the specified {@code PrintStream}.
      * Delegates construction of the usage help message to the {@link Help} inner class and is equivalent to:
@@ -1500,27 +1513,27 @@ public class CommandLine {
      * @param colorScheme the {@code ColorScheme} defining the styles for options, parameters and commands when ANSI is enabled
      */
     public void usage(PrintStream out, Help.ColorScheme colorScheme) {
-        out.print(usage(new StringBuilder(), new Help(getCommandSpec(), colorScheme)));
+        out.print(usage(new StringBuilder(), getHelpFactory().create(getCommandSpec(), colorScheme)));
     }
     /** Similar to {@link #usage(PrintStream, Help.ColorScheme)}, but with the specified {@code PrintWriter} instead of a {@code PrintStream}.
      * @since 3.0 */
     public void usage(PrintWriter writer, Help.ColorScheme colorScheme) {
-        writer.print(usage(new StringBuilder(), new Help(getCommandSpec(), colorScheme)));
+        writer.print(usage(new StringBuilder(), getHelpFactory().create(getCommandSpec(), colorScheme)));
     }
     /** Similar to {@link #usage(PrintStream)}, but returns the usage help message as a String instead of printing it to the {@code PrintStream}.
      * @since 3.2 */
     public String getUsageMessage() {
-        return usage(new StringBuilder(), new Help(getCommandSpec())).toString();
+        return usage(new StringBuilder(), getHelpFactory().create(getCommandSpec(), Help.defaultColorScheme(Help.Ansi.AUTO))).toString();
     }
     /** Similar to {@link #usage(PrintStream, Help.Ansi)}, but returns the usage help message as a String instead of printing it to the {@code PrintStream}.
      * @since 3.2 */
     public String getUsageMessage(Help.Ansi ansi) {
-        return usage(new StringBuilder(), new Help(getCommandSpec(), ansi)).toString();
+        return usage(new StringBuilder(), getHelpFactory().create(getCommandSpec(), Help.defaultColorScheme(ansi))).toString();
     }
     /** Similar to {@link #usage(PrintStream, Help.ColorScheme)}, but returns the usage help message as a String instead of printing it to the {@code PrintStream}.
      * @since 3.2 */
     public String getUsageMessage(Help.ColorScheme colorScheme) {
-        return usage(new StringBuilder(), new Help(getCommandSpec(), colorScheme)).toString();
+        return usage(new StringBuilder(), getHelpFactory().create(getCommandSpec(), colorScheme)).toString();
     }
     private static StringBuilder usage(StringBuilder sb, Help help) {
         return sb.append(help.headerHeading())
@@ -3214,6 +3227,18 @@ public class CommandLine {
         public String defaultValue(ArgSpec argSpec) { throw new UnsupportedOperationException(); }
     }
 
+    public interface IHelpFactory {
+        Help create(CommandSpec commandSpec, Help.ColorScheme colorScheme);
+    }
+    
+    public static class DefaultHelpFactory implements IHelpFactory {
+
+        public Help create(CommandSpec commandSpec, Help.ColorScheme colorScheme) {
+            return new Help(commandSpec, colorScheme);
+        }
+        
+    }
+    
     /**
      * Factory for instantiating classes that are registered declaratively with annotation attributes, like
      * {@link Command#subcommands()}, {@link Option#converter()}, {@link Parameters#converter()} and {@link Command#versionProvider()}.


### PR DESCRIPTION
Issue #530 
Changes based on stechios changes and your suggestions.
Does this comply with your suggestions? Just say what you think.
First ever pull request, so I don't know what I am doing github-wise.
I assume that every new Help(...) inside of Help needs to be replaced by the factory?

For me all of this usage customization only has a value when Help.detailedSynopsis is split into multiple methods. This affects synopsis Help.synopsis(int). So I suggest making the switch between custom, abbreviated and detailed synopsis in Help.sections. Plus some code reuse to implement Help.synopsis(int) if the interface should not break. I think it fits this issue, or should i open a new issue for that?

My agenda: I like to see some parameters in usage instead of commandSpec.qualifiedName() and want to replace qualifiedName() with a subcommand-loop. e.g. we do 'thingy 119 update foo=13' and expect as subcommand help synopsis: thingy <id> update.