### PR TITLE
Make CommandLine in AutoComplete use correct IFactory implementation

### DIFF
--- a/src/main/java/picocli/AutoComplete.java
+++ b/src/main/java/picocli/AutoComplete.java
@@ -137,7 +137,7 @@ public class AutoComplete {
                 }
                 Class<?> cls = Class.forName(commandLineFQCN);
                 Object instance = factory.create(cls);
-                CommandLine commandLine = new CommandLine(instance);
+                CommandLine commandLine = new CommandLine(instance, factory);
 
                 if (commandName == null) {
                     commandName = commandLine.getCommandName(); //new CommandLine.Help(commandLine.commandDescriptor).commandName;


### PR DESCRIPTION
In some cases using the DefaultFactory when instantiating CommandLine could cause subcommands that require a specific implementation to fail to be created. This commit makes the CommandLine instance use the IFactory implementation passed by the user to the AutoComplete command (if any) which should resolve this issue.

Closes #601