### PR TITLE
Change % to %% when using ${DEFAULT-VALUE} in option description

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -5329,7 +5329,7 @@ public class CommandLine {
                 String defaultValueString = defaultValueString();
                 String[] result = new String[desc.length];
                 for (int i = 0; i < desc.length; i++) {
-                    result[i] = format(desc[i].replace(DESCRIPTION_VARIABLE_DEFAULT_VALUE, defaultValueString)
+                    result[i] = format(desc[i].replace(DESCRIPTION_VARIABLE_DEFAULT_VALUE, defaultValueString.replace("%", "%%"))
                             .replace(DESCRIPTION_VARIABLE_COMPLETION_CANDIDATES, candidates.toString()));
                 }
                 return result;

--- a/src/test/java/picocli/CommandLineHelpTest.java
+++ b/src/test/java/picocli/CommandLineHelpTest.java
@@ -3772,4 +3772,27 @@ public class CommandLineHelpTest {
                         "Using raw String: '%n' format strings have not been replaced with newlines. " +
                         "Please ensure to escape '%' characters with another '%'."));
     }
+
+    @Test
+    public void testDescriptionWithDefaultValueContainingPercentChar() {
+        class App {
+            @Option(names = {"-f"},
+                    defaultValue = "%s - page %d of %d",
+                    description = "format string. Default: ${DEFAULT-VALUE}")
+            public String formatString;
+        }
+        String expected = String.format("" +
+                "Usage: <main class> [-f=<formatString>]%n" +
+                "  -f=<formatString>    format string. Default: %%s - page %%d of %%d%n");
+        String actual = new CommandLine(new App()).getUsageMessage();
+        assertEquals(expected, actual);
+
+        assertFalse(systemErrRule.getLog().contains(
+                "[picocli WARN] Could not format 'format string. Default: %s - page %d of %d' " +
+                        "(Underlying error:"));
+        assertFalse(systemErrRule.getLog().contains(
+                "). " +
+                        "Using raw String: '%n' format strings have not been replaced with newlines. " +
+                        "Please ensure to escape '%' characters with another '%'."));
+    }
 }


### PR DESCRIPTION
Percent signs shall be escaped in the description text as it is going
to be passed to String.format. If the default value contains (single) %
signs then using the built-in DEFAULT-VALUE variable would lead to a
warning message. This is avoided by escaping any % signs in the
DEFAULT-VALUE variable when used in the description.

This is related to #615 and its fix. I have an option with a default value of "%s - page %d of %d" and using ${DEFAULT-VALUE} in the description leads to the warning message. A workaround would have been to not use ${DEFAULT-VALUE} but instead writing the default value with doulbe % signs in the description but I definitely prefer the use of the variable just in case the default changes some time later.