### PR TITLE
Introduce a failing test for char[] type conversion

### DIFF
--- a/src/test/java/picocli/CommandLineTypeConversionTest.java
+++ b/src/test/java/picocli/CommandLineTypeConversionTest.java
@@ -64,6 +64,7 @@ public class CommandLineTypeConversionTest {
         @Option(names = "-Byte")          Byte aByteField;
         @Option(names = "-char")          char charField;
         @Option(names = "-Character")     Character aCharacterField;
+        @Option(names = "-charArray")     char[] charArrayField;
         @Option(names = "-short")         short shortField;
         @Option(names = "-Short")         Short aShortField;
         @Option(names = "-int")           int intField;
@@ -493,6 +494,16 @@ public class CommandLineTypeConversionTest {
             fail("Invalid format was accepted");
         } catch (CommandLine.ParameterException expected) {
             assertEquals("Invalid value for option '-char': 'aa' is not a single character", expected.getMessage());
+        }
+    }
+    @Test
+    public void testCharArrayConverter() {
+        try {
+            final SupportedTypes cli = new SupportedTypes();
+            CommandLine.populateCommand(new SupportedTypes(), "-charArray", "abcd");
+            assertEquals(new char[]{'a', 'b', 'c', 'd'}, cli.charArrayField);
+        } catch (Exception exception) {
+            fail("Unexpected exception while converting char[] type: " + exception.getMessage());
         }
     }
     @Test


### PR DESCRIPTION
When I have a `char[]`-typed `@Option` in my command-line object, I get an error when trying to set it from the command line:

    Invalid value for option '-charArray' (<charArrayField>): 'abcd' is not a single character

It appears that Picocli treats `char[]` as `char`. The expected behavior instead would be that the input `String` is converted to `char[]` using its `toCharArray()` method.

Couple more notes:

- Using `char[]` as the data type is a pretty common thing when the parameter is a password. The array can be manually zeroed when the password is no longer needed, thus completely removing it from memory while its parent object still lives.
- Using `String` for the same purpose is sub-optimal, as JVM does all kinds of magic with `Strings` and the password could, for example, be interned - irrevocably burning it into the JVM memory for the entire runtime of the application.
- The original code is lifted directly from a JCommander-based implementation, which handled this situation properly.
- I attempted to fix the problem, but the type conversion code seems very convoluted. Without gaining a deep understanding of all the code branches, I risk causing more problems than I solve.

