### PR TITLE
Fixing the provided flag usage in the read me

### DIFF
--- a/picocli-codegen/README.adoc
+++ b/picocli-codegen/README.adoc
@@ -70,7 +70,7 @@ An alternative that works with older versions of the `maven-compiler-plugin` is 
   <groupId>info.picocli</groupId>
   <artifactId>picocli-codegen</artifactId>
   <version>4.0.1</version>
-  <provided>true</provided>
+  <scope>provided</scope>
 </dependency>
 ```
 


### PR DESCRIPTION
The provided flag should be added as the scope:
`<scope>provided</scope>`