### PR TITLE
Using TreeMap instead of LinkedHashMap, to sort subcommands alphabeti…

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -351,7 +351,7 @@ public class CommandLine {
      * @since 0.9.7
      */
     public Map<String, CommandLine> getSubcommands() {
-        return new LinkedHashMap<String, CommandLine>(getCommandSpec().subcommands());
+        return new TreeMap<String, CommandLine>(getCommandSpec().subcommands());
     }
     /**
      * Returns the command that this is a subcommand of, or {@code null} if this is a top-level command.
@@ -5051,7 +5051,7 @@ public class CommandLine {
             /** Constant Boolean holding the default setting for whether variables should be interpolated in String values: <code>{@value}</code>.*/
             static final Boolean DEFAULT_INTERPOLATE_VARIABLES = true;
 
-            private final Map<String, CommandLine> commands = new LinkedHashMap<String, CommandLine>();
+            private final Map<String, CommandLine> commands = new TreeMap<String, CommandLine>();
             private final Map<String, OptionSpec> optionsByNameMap = new LinkedHashMap<String, OptionSpec>();
             private final Map<String, OptionSpec> negatedOptionsByNameMap = new LinkedHashMap<String, OptionSpec>();
             private final Map<Character, OptionSpec> posixOptionsByKeyMap = new LinkedHashMap<Character, OptionSpec>();


### PR DESCRIPTION
Using TreeMap instead of LinkedHashMap, to sort subcommands alphabetically in usage message.

Tell me if that breaks something.

Below is a snippet to toy with the expected behaviour (with/without ordering).

` 
public class TestApplication {

	@Command(name = "alpha")
	public static class Alpha implements Callable<Integer> {
		@Override
		public Integer call() throws Exception {
			return 0;
		}
	}

	@Command(name = "bravo")
	public static class Bravo implements Callable<Integer> {
		@Override
		public Integer call() throws Exception {
			return 0;
		}
	}

	@Command(name = "charlie")
	public static class Charlie implements Callable<Integer> {
		@Override
		public Integer call() throws Exception {
			return 0;
		}
	}

	@Command(name = "$",
			subcommands = {
				Charlie.class,
				Bravo.class,
				Alpha.class,
				HelpCommand.class
			})
	public static class RootCommand implements Callable<Integer> {
		@Override
		public Integer call() throws Exception {
			throw new UnsupportedOperationException();
		}
	}

	public static void main(String[] args) {
		CommandLine rootCommand = new CommandLine(new RootCommand());
		rootCommand.usage(System.out);
	}
}
`