### PR TITLE
Add command() to ArgSpec

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -7366,6 +7366,10 @@ public class CommandLine {
              * @since 4.0 */
             public ArgGroupSpec group() { return group; }
 
+            /** Returns the command this option or positional parameter belongs to.
+             * @since 4.1 */
+            public CommandSpec command() { return commandSpec; }
+
             /** Returns the untyped command line arguments matched by this option or positional parameter spec.
              * @return the matched arguments after {@linkplain #splitRegex() splitting}, but before type conversion.
              *      For map properties, {@code "key=value"} values are split into the key and the value part. */

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -7367,6 +7367,10 @@ public class CommandLine {
             public ArgGroupSpec group() { return group; }
 
             /** Returns the command this option or positional parameter belongs to.
+             * <p>Beware that it is possible to programmatically add an option or positional parameter to more than one command model.
+             * (This will not happen in models that are auto-generated from annotations). In that case this method will only return
+             * the one it was added to last.
+             * <p>If the option or positional parameter has not yet been attached to a command, {@code null} will be returned.
              * @since 4.1 */
             public CommandSpec command() { return commandSpec; }
 

--- a/src/test/java/picocli/ModelOptionSpecTest.java
+++ b/src/test/java/picocli/ModelOptionSpecTest.java
@@ -1,9 +1,12 @@
 package picocli;
 
 import org.junit.Test;
+
+import picocli.CommandLine.Command;
 import picocli.CommandLine.Help.Visibility;
 import picocli.CommandLine.ITypeConverter;
 import picocli.CommandLine.InitializationException;
+import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Model.IGetter;
 import picocli.CommandLine.Model.ISetter;
 import picocli.CommandLine.Model.OptionSpec;
@@ -315,6 +318,25 @@ public class ModelOptionSpecTest {
         // no errors
         OptionSpec.builder("-x").arity("0").interactive(true).build();
         OptionSpec.builder("-x").arity("0..1").interactive(true).build();
+    }
+
+    @Test
+    public void testOptionHasCommand() {
+        class App {
+            @Option(names = "-x") int x;
+        }
+
+        CommandSpec cmd = new CommandLine(new App()).getCommandSpec();
+        CommandSpec cmd2 = new CommandLine(new App()).getCommandSpec();
+        OptionSpec optx = cmd.findOption('x');
+        assertEquals(cmd, optx.command());
+        OptionSpec opty = OptionSpec.builder("-y").arity("1").build();
+        assertEquals(null, opty.command());
+        cmd.add(opty);
+        assertEquals(cmd, opty.command());
+        cmd2.add(opty);
+        assertEquals(cmd2, opty.command());
+        assertEquals(opty, cmd.findOption('y'));
     }
 
     @Test

--- a/src/test/java/picocli/ModelPositionalParamSpecTest.java
+++ b/src/test/java/picocli/ModelPositionalParamSpecTest.java
@@ -3,8 +3,11 @@ package picocli;
 import org.junit.Test;
 import picocli.CommandLine.Help.Visibility;
 import picocli.CommandLine.ITypeConverter;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Model.IGetter;
 import picocli.CommandLine.Model.ISetter;
+import picocli.CommandLine.Model.OptionSpec;
 import picocli.CommandLine.Model.PositionalParamSpec;
 import picocli.CommandLine.Parameters;
 import picocli.CommandLine.Range;
@@ -233,6 +236,25 @@ public class ModelPositionalParamSpecTest {
         assertTrue(cmd.getCommandSpec().positionalParameters().get(0).interactive());
         assertFalse(cmd.getCommandSpec().positionalParameters().get(1).interactive());
         assertFalse(cmd.getCommandSpec().positionalParameters().get(2).interactive());
+    }
+
+    @Test
+    public void testParameterHasCommand() {
+        class App {
+            @Parameters(index="0") int x;
+        }
+
+        CommandSpec cmd = new CommandLine(new App()).getCommandSpec();
+        CommandSpec cmd2 = new CommandLine(new App()).getCommandSpec();
+        PositionalParamSpec param = cmd.positionalParameters().get(0);
+        assertEquals(cmd, param.command());
+        PositionalParamSpec param1 = PositionalParamSpec.builder().index("1").build();
+        assertEquals(null, param1.command());
+        cmd.add(param1);
+        assertEquals(cmd, param1.command());
+        cmd2.add(param1);
+        assertEquals(cmd2, param1.command());
+        assertEquals(param1, cmd.positionalParameters().get(1));
     }
 
     @Test


### PR DESCRIPTION
There seems to be no public way to get from an `ArgSpec` to the command model it belongs to. Expose the existing field with a getter method.

My use case for this is so I can write a single generic `IDefaultValueProvider` that is sensitive to which subcommand it is getting a default for. This makes it simpler to implement [Bazel-style config files](https://docs.bazel.build/guide.html#bazelrc-syntax-and-semantics) that provide a uniform way to override defaults for all command-line options.

(If I'm overlooking something obvious, please advise).