### PR TITLE
Use toString() to match enum constants

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -11987,19 +11987,17 @@ public class CommandLine {
                 return new ITypeConverter<Object>() {
                     @SuppressWarnings("unchecked")
                     public Object convert(String value) throws Exception {
-                        String sensitivity = "case-sensitive";
-                        if (commandSpec.parser().caseInsensitiveEnumValuesAllowed()) {
-                            String upper = value.toUpperCase();
-                            for (Object enumConstant : type.getEnumConstants()) {
-                                if (upper.equals(String.valueOf(enumConstant).toUpperCase())) { return enumConstant; }
-                            }
-                            sensitivity = "case-insensitive";
-                        }
                         try { return Enum.valueOf((Class<Enum>) type, value); }
-                        catch (Exception ex) {
+                        catch (IllegalArgumentException ex) {
+                            boolean insensitive = commandSpec.parser().caseInsensitiveEnumValuesAllowed();
+                            for (Object enumConstant : type.getEnumConstants()) {
+                                String thisName = enumConstant.toString();
+                                if( value.equals(thisName) || insensitive && value.equalsIgnoreCase(thisName) ) { return enumConstant; }
+                            }
+                            String sensitivity = insensitive ? "case-insensitive" : "case-sensitive";
                             Enum<?>[] constants = ((Class<Enum<?>>) type).getEnumConstants();
                             String[] names = new String[constants.length];
-                            for (int i = 0; i < names.length; i++) { names[i] = constants[i].name(); }
+                            for (int i = 0; i < names.length; i++) { names[i] = constants[i].toString(); }
                             throw new TypeConversionException(
                                     String.format("expected one of %s (%s) but was '%s'", Arrays.asList(names), sensitivity, value)); }
                     }


### PR DESCRIPTION
Picocli sometimes uses `toString()` to get the name of an enum constant, at other times `name()`. These can be different if one overrides `toString()` in the `enum` type declaration, and in that case it is probably because one _wants_ the external name of the enum constant to be different from its source-code name. So that is what options should work in terms of.

The `${COMPLETION-CANDITATES}` usage-help interpolation for enum-type arguments already uses `toString()` to display the options.

This PR fixes the default type converter such that it works in terms of `toString()` rather than `name()`. It initially will try to match the argument against the raw name using `Enum.valueOf()` because that might use more efficient lookup tables internally (and arguably if someone creates an enum constant whose `toString()` returns the source-level name of a _different_ constant in the same enum, they're setting themselves up for failure anyway).