### PR TITLE
Minor improvements and corrections to groovy examples

### DIFF
--- a/picocli-examples/src/main/groovy/picocli/examples/UserManualExample.groovy
+++ b/picocli-examples/src/main/groovy/picocli/examples/UserManualExample.groovy
@@ -4,7 +4,7 @@ import picocli.CommandLine
 import picocli.CommandLine.Command
 import picocli.CommandLine.Option
 
-@Command(name = "MyApp", version = "Groovy picocli demo v3.0",
+@Command(name = "MyApp", version = "Groovy picocli demo v4.1",
         mixinStandardHelpOptions = true,
         description = "@|bold Groovy|@ @|underline picocli|@ example")
 class UserManualExample implements Runnable {
@@ -20,6 +20,7 @@ class UserManualExample implements Runnable {
     }
 
     static void main(String[] args) {
-        CommandLine.run(new UserManualExample(), args)
+        CommandLine cmd = new CommandLine(new UserManualExample())
+        cmd.execute(args)
     }
 }

--- a/picocli-examples/src/main/groovy/picocli/examples/UserManualScriptExample.groovy
+++ b/picocli-examples/src/main/groovy/picocli/examples/UserManualScriptExample.groovy
@@ -1,6 +1,6 @@
 package picocli.examples
 
-@Grab('info.picocli:picocli-groovy:4.0.0')
+@Grab('info.picocli:picocli-groovy:4.1.1')
 @Command(name = "myCommand",
         mixinStandardHelpOptions = true,
         description = "@|bold Groovy script|@ @|underline picocli|@ example")

--- a/picocli-examples/src/main/groovy/picocli/examples/checksum-with-banner.groovy
+++ b/picocli-examples/src/main/groovy/picocli/examples/checksum-with-banner.groovy
@@ -1,6 +1,6 @@
 package picocli.examples
 
-@Grab('info.picocli:picocli-groovy:4.0.0')
+@Grab('info.picocli:picocli-groovy:4.1.1')
 @GrabExclude('org.codehaus.groovy:groovy-all')
 @Command(header = [
         $/@|bold,green    ___                            ___ _           _                  |@/$,

--- a/picocli-examples/src/main/groovy/picocli/examples/checksum-without-base.groovy
+++ b/picocli-examples/src/main/groovy/picocli/examples/checksum-without-base.groovy
@@ -1,6 +1,6 @@
 package picocli.examples
 
-@Grab('info.picocli:picocli-groovy:4.0.0')
+@Grab('info.picocli:picocli-groovy:4.1.1')
 @GrabExclude('org.codehaus.groovy:groovy-all')
 import java.security.MessageDigest
 import picocli.CommandLine
@@ -20,7 +20,7 @@ class Checksum {
 Checksum checksum = new Checksum()
 CommandLine commandLine = new CommandLine(checksum)
 try {
-    commandLine.parse(args)
+    commandLine.parseArgs(args)
     if (commandLine.usageHelpRequested) {
         commandLine.usage(System.out)
     } else {

--- a/picocli-examples/src/main/groovy/picocli/examples/checksum.groovy
+++ b/picocli-examples/src/main/groovy/picocli/examples/checksum.groovy
@@ -1,6 +1,6 @@
 package picocli.examples
 
-@Grab('info.picocli:picocli-groovy:4.0.0')
+@Grab('info.picocli:picocli-groovy:4.1.1')
 @GrabExclude('org.codehaus.groovy:groovy-all')
 @picocli.groovy.PicocliScript
 import groovy.transform.Field

--- a/picocli-examples/src/main/groovy/picocli/examples/simple.groovy
+++ b/picocli-examples/src/main/groovy/picocli/examples/simple.groovy
@@ -1,6 +1,6 @@
 package picocli.examples
 
-@Grab('info.picocli:picocli-groovy:4.0.0')
+@Grab('info.picocli:picocli-groovy:4.1.1')
 @GrabExclude('org.codehaus.groovy:groovy-all')
 @picocli.groovy.PicocliScript
 @picocli.CommandLine.Command

--- a/picocli-groovy/README.md
+++ b/picocli-groovy/README.md
@@ -1,4 +1,6 @@
-<p align="center"><img src="https://picocli.info/images/groovy-logo.png" height="150px"><img src="https://picocli.info/images/logo/horizontal-400x150.png" alt="picocli" height="150px"></p>
+<p align="center">
+<a href="https://groovy-lang.org"><img src="https://picocli.info/images/groovy-logo.png" height="150px" alt="Groovy programming language"></a>
+<a href="https://picocli.info"><img src="https://picocli.info/images/logo/horizontal-400x150.png" alt="picocli" height="150px"></p></a>
 
 
 # Picocli in Groovy Scripts
@@ -25,7 +27,7 @@ import static picocli.CommandLine.*
 
 @Option(names = ["-a", "--algorithm"], description = [
         "MD2, MD5, SHA-1, SHA-256, SHA-384, SHA-512, or",
-        "  any other MessageDigest algorithm. See [1] for more details."])
+        "  any other MessageDigest algorithm."])
 @Field private String algorithm = "MD5"
 
 files.each {


### PR DESCRIPTION
I realised that the README.md of the `picocli-groovy` lists an example that states in the description of the option `algorithm`: 
 
`See [1] for more details.`

There is no footer with a reference [1], though.

Removed this passage.