### PR TITLE
More Java and Kotlin examples

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -329,7 +329,7 @@ Another idea is to add a separate different option (that could be named `--passw
 
 A command that combines either of these with an interactive `--password` option (with the default `arity = "0"`) allows end users to provide a password without specifying it in plain text on the command line. Such a command can be executed both interactively and in batch mode.
 
-The `picocli-examples` module has https://github.com/remkop/picocli/blob/master/picocli-examples/src/main/java/picocli/examples/interactive/PasswordDemo.java[an example].
+The https://github.com/remkop/picocli/blob/master/picocli-examples[`picocli-examples`] module has an example, coded both in https://github.com/remkop/picocli/blob/master/picocli-examples/src/main/java/picocli/examples/interactive/PasswordDemo.java[Java] and https://github.com/remkop/picocli/tree/master/picocli-examples/src/main/kotlin/picocli/examples/kotlin/interactive/PasswordDemo.kt[Kotlin].
 ====
 
 [CAUTION]

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -3598,8 +3598,11 @@ Would result in this help fragment:
 ----
 status, st    Show the working tree status.
 ----
+
 === Subcommands as Methods
-From picocli 3.6 it is possible to register subcommands in a very compact manner by having a `@Command` class with `@Command`-annotated methods. The methods are automatically <<Subcommand Methods, registered as subcommands>> of the `@Command` class.
+As of picocli 3.6 it is possible to register subcommands in a very compact manner by having a `@Command` class with `@Command`-annotated methods. The methods are automatically <<Subcommand Methods, registered as subcommands>> of the `@Command` class.
+
+The https://github.com/remkop/picocli/blob/master/picocli-examples[`picocli-examples`] module has an  minimal example application, demonstrating the definition of subcommands via methods. This example was coded both in https://github.com/remkop/picocli/blob/master/picocli-examples/src/main/java/picocli/examples/subcommands/SubCmdsViaMethods.java[Java] and https://github.com/remkop/picocli/blob/master/picocli-examples/src/main/kotlin/picocli/examples/kotlin/subcommands/SubCmdsViaMethods.kt[Kotlin].
 
 === Executing Subcommands
 

--- a/picocli-examples/src/main/java/picocli/examples/subcommands/SubCmdsViaMethods.java
+++ b/picocli-examples/src/main/java/picocli/examples/subcommands/SubCmdsViaMethods.java
@@ -1,0 +1,46 @@
+package picocli.examples.subcommands;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.ParameterException;
+import picocli.CommandLine.Spec;
+import java.util.Locale;
+
+@Command(name = "ISOCodeResolve", subcommands = { CommandLine.HelpCommand.class },
+         description = "Resolve ISO country codes (ISO-3166-1) or language codes (ISO 639-1 or -2)")
+public class SubCmdsViaMethods implements Runnable {
+    @Spec CommandSpec spec;
+    
+    @Command(name = "country", description = "Resolve ISO country code (ISO-3166-1, Alpha-2 code)")
+    void country(@Parameters(arity = "1..*", paramLabel = "<country code 1> <country code 2>",
+                 description = "country code(s) to be resolved") String[] countryCodes) {
+        for (String code : countryCodes) {
+            System.out.println(String.format("%s: %s", code.toUpperCase(), new Locale("", code).getDisplayCountry()));
+        }
+    }
+
+    @Command(name = "language", description = "Resolve ISO language code (ISO 639-1 or -2, two/three letters)")
+    void language(@Parameters(arity = "1..*", paramLabel = "<language code 1> <language code 2>",
+                  description = "language code(s) to be resolved") String[] languageCodes) {
+        for (String code : languageCodes) {
+            System.out.println(String.format("%s: %s", code.toLowerCase(), new Locale(code).getDisplayLanguage()));
+        }
+    }
+
+    @Override
+    public void run() {
+        throw new ParameterException(spec.commandLine(), "Specify a subcommand");
+    }
+
+    public static void main(String[] args) {
+        CommandLine cmd = new CommandLine(new SubCmdsViaMethods());
+        if (args.length == 0) {
+            cmd.usage(System.out);
+        }
+        else {
+            cmd.execute(args);
+        }
+    }
+}

--- a/picocli-examples/src/main/kotlin/picocli/examples/kotlin/Checksum.kt
+++ b/picocli-examples/src/main/kotlin/picocli/examples/kotlin/Checksum.kt
@@ -11,6 +11,7 @@ import java.math.BigInteger
 import java.nio.file.Files
 import java.security.MessageDigest
 import java.util.concurrent.Callable
+import kotlin.system.exitProcess
 
 @Command(name = "checksum", mixinStandardHelpOptions = true,
         subcommands = [ HelpCommand::class ], version = ["checksum 4.1.4"],
@@ -34,6 +35,12 @@ class Checksum : Callable<Int> {
 
         return 0
     }
-}
 
-fun main(args: Array<String>) = System.exit(CommandLine(Checksum()).execute(*args))
+    companion object {
+        @JvmStatic fun main(args: Array<String>) {
+            CommandLine(Checksum()).execute(*args)
+        }
+    }
+}
+// NOTE: below is an alternative to defining a @JvmStatic main function in a companion object:
+// fun main(args: Array<String>) : Unit = exitProcess(CommandLine(Checksum()).execute(*args))

--- a/picocli-examples/src/main/kotlin/picocli/examples/kotlin/MyApp.kt
+++ b/picocli-examples/src/main/kotlin/picocli/examples/kotlin/MyApp.kt
@@ -1,8 +1,9 @@
-package picocli.examples.kotlin
+//package picocli.examples.kotlin.subcommands
 
 import picocli.CommandLine
 import picocli.CommandLine.*
 import java.util.concurrent.Callable
+import kotlin.system.exitProcess
 
 @Command(name = "MyApp", version = ["Kotlin picocli demo v4.0"],
         mixinStandardHelpOptions = true,
@@ -15,16 +16,16 @@ class MyApp : Callable<Int> {
     private var count: Int = 0
 
     override fun call(): Int {
-        for (i in 0 until count) {
-            println("hello world $i...")
+        repeat (count) {
+            println("hello world $it...")
         }
         return 123
     }
     companion object {
         @JvmStatic fun main(args: Array<String>) {
-            CommandLine.run(MyApp(), *args)
+            CommandLine(MyApp()).execute(*args)
         }
     }
 }
 // NOTE: below is an alternative to defining a @JvmStatic main function in a companion object:
-//fun main(args: Array<String>) = System.exit(CommandLine(MyApp()).execute(*args))
+// fun main(args: Array<String>) = exitProcess(CommandLine(MyApp()).execute(*args))

--- a/picocli-examples/src/main/kotlin/picocli/examples/kotlin/interactive/PasswordDemo.kt
+++ b/picocli-examples/src/main/kotlin/picocli/examples/kotlin/interactive/PasswordDemo.kt
@@ -1,0 +1,47 @@
+package picocli.examples.kotlin.interactive
+
+import picocli.CommandLine
+import picocli.CommandLine.*
+import picocli.CommandLine.Model.CommandSpec
+import java.io.File
+import java.nio.file.Files
+import kotlin.system.exitProcess
+
+class PasswordDemo : Runnable {
+    @Option(names = ["--password:file"])
+    var passwordFile: File? = null
+    @Option(names = ["--password:env"])
+    var passwordEnvironmentVariable: String? = null
+    @Option(names = ["--password"], interactive = true)
+    var password: String? = null
+    @Spec
+    var spec: CommandSpec? = null
+
+    override fun run() {
+        when {
+            password != null -> {
+                login(password!!)
+            }
+            passwordEnvironmentVariable != null -> {
+                login(System.getenv(passwordEnvironmentVariable))
+            }
+            passwordFile != null -> {
+                login(String(Files.readAllBytes(passwordFile!!.toPath())))
+            }
+            else -> {
+                throw ParameterException(spec!!.commandLine(), "Password required")
+            }
+        }
+    }
+
+    private fun login(pwd: String) {
+        println("Password: %s%n".format(pwd))
+    }
+    companion object {
+        @JvmStatic fun main(args: Array<String>) {
+            CommandLine(PasswordDemo()).execute(*args)
+        }
+    }
+}
+// NOTE: below is an alternative to defining a @JvmStatic main function in a companion object:
+// fun main(): Unit = exitProcess(CommandLine(PasswordDemo()).execute("--password"))

--- a/picocli-examples/src/main/kotlin/picocli/examples/kotlin/subcommands/SubCmdsViaMethods.kt
+++ b/picocli-examples/src/main/kotlin/picocli/examples/kotlin/subcommands/SubCmdsViaMethods.kt
@@ -4,16 +4,17 @@ import picocli.CommandLine
 import picocli.CommandLine.Command
 import picocli.CommandLine.HelpCommand
 import java.util.Locale
+import kotlin.system.exitProcess
 
 @Command(name = "ISOCodeResolve", mixinStandardHelpOptions = true, version = ["1.0"], subcommands = [ HelpCommand::class ],
-        description = ["Resolve ISO country codes (ISO-3166-1) or language codes (ISO 639-1 or -2)"])
+    description = ["Resolve ISO country codes (ISO-3166-1) or language codes (ISO 639-1 or -2)"])
 class SubCmdsViaMethods : Runnable  {
     @CommandLine.Spec
     val spec: CommandLine.Model.CommandSpec? = null
 
     @Command(description = ["Resolve ISO country code (ISO-3166-1, Alpha-2 code)"])
     fun country( @CommandLine.Parameters( arity = "1..*n", paramLabel = "<country1> <country2>",
-            description = ["country code(s) to be resolved"] ) vararg countryCodes : String)
+        description = ["country code(s) to be resolved"] ) vararg countryCodes : String)
     {
         for (code in countryCodes) {
             println("${code.toUpperCase()}: " + Locale("", code).displayCountry)
@@ -22,7 +23,7 @@ class SubCmdsViaMethods : Runnable  {
 
     @Command(description = ["Resolve ISO language code (ISO 639-1 or -2, two/three letters)"])
     fun language( @CommandLine.Parameters( arity = "1..*n", paramLabel = "<code> <code2>",
-            description = ["language code(s) to be resolved"] ) vararg languageCodes : String)
+        description = ["language code(s) to be resolved"] ) vararg languageCodes : String)
     {
         for (code in languageCodes) {
             println("${code.toUpperCase()}: " + Locale(code).displayLanguage)
@@ -30,6 +31,12 @@ class SubCmdsViaMethods : Runnable  {
     }
 
     override fun run() = throw CommandLine.ParameterException(spec?.commandLine(), "Specify a subcommand")
-}
 
-fun main(args: Array<String>) = System.exit(CommandLine(SubCmdsViaMethods()).execute(*args))
+    companion object {
+        @JvmStatic fun main(args: Array<String>) {
+            CommandLine(SubCmdsViaMethods()).execute(*args)
+        }
+    }
+}
+// NOTE: below is an alternative to defining a @JvmStatic main function in a companion object:
+// fun main(args: Array<String>) : Unit = exitProcess(CommandLine(SubCmdsViaMethods()).execute(*args))


### PR DESCRIPTION
This patch provides further example files, coded both in Java and Kotlin. References to the newly added files were added to the manual, too.

This patch also corrects the Kotlin MyApp example which currently does not compile:

```
companion object {
    @JvmStatic fun main(args: Array<String>) {
        CommandLine.run(MyApp(), *args)
    }
}
```

Inside the companion object, `CommandLine.run()` is called, however, MyApp implements `Callable` and not `Runnable`.
Since both methods `run()` and `call()` are deprecated, I changed this to `CommandLine(MyApp()).execute(*args)`.

In order to prevent these kind of errors in the future, I would propose to add a task `compileKotlin` to the file `build.gradle` of the `picocli-examples` module.