### PR TITLE
latest snapshot version for spring dependencies

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -4884,14 +4884,14 @@ Maven:
 <dependency>
   <groupId>info.picocli</groupId>
   <artifactId>picocli-spring-boot-starter</artifactId>
-  <version>4.0.1</version>
+  <version>4.2.0-SNAPSHOT</version>
 </dependency>
 ```
 
 Gradle:
 ```
 dependencies {
-    compile "info.picocli:picocli-spring-boot-starter:4.0.1"
+    compile "info.picocli:picocli-spring-boot-starter:4.2.0-SNAPSHOT"
 }
 ```
 


### PR DESCRIPTION
websites dependencies in spring boot section are outdated (4.0.1 currently)