### PR TITLE
#991 more robust terminal width detection for international Windows versions

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -6679,7 +6679,9 @@ public class CommandLine {
                                 txt += " " + line;
                             }
                             tracer.debug("getTerminalWidth() parsing output: %s%n", txt);
-                            Pattern pattern = Pattern.compile(".*olumns(:)?\\s+(\\d+)\\D.*", Pattern.DOTALL);
+                            Pattern pattern = (Help.Ansi.isWindows() && !Help.Ansi.isPseudoTTY())
+                                    ? Pattern.compile(".*?:\\s*(\\d+)\\D.*?:\\s*(\\d+)\\D.*", Pattern.DOTALL)
+                            		: Pattern.compile(".*olumns(:)?\\s+(\\d+)\\D.*", Pattern.DOTALL);
                             Matcher matcher = pattern.matcher(txt);
                             if (matcher.matches()) {
                                 size.set(Integer.parseInt(matcher.group(2)));
@@ -6697,7 +6699,7 @@ public class CommandLine {
                 do {
                     if (size.intValue() >= 0) { break; }
                     try { Thread.sleep(25); } catch (InterruptedException ignored) {}
-                } while (System.currentTimeMillis() < now + 2000);
+                } while (System.currentTimeMillis() < now + 2000 && t.isAlive());
                 double duration = (System.nanoTime() - start) / 1000000.0;
                 tracer.debug("getTerminalWidth() returning: %s in %,.1fms%n", size, duration);
                 return size.intValue();

--- a/src/test/java/picocli/HelpTest.java
+++ b/src/test/java/picocli/HelpTest.java
@@ -3619,7 +3619,24 @@ public class HelpTest {
                 "    Keyboard delay: 1\n" +
                 "    Code page:      932\n" +
                 "\n";
-        Pattern pattern = Pattern.compile(".*olumns(:)?\\s+(\\d+)\\D.*", Pattern.DOTALL);
+        Pattern pattern = Pattern.compile(".*?:\\s*(\\d+)\\D.*?:\\s*(\\d+)\\D.*", Pattern.DOTALL);
+        Matcher matcher = pattern.matcher(sttyResult);
+        assertTrue(matcher.matches());
+        assertEquals(113, Integer.parseInt(matcher.group(2)));
+    }
+
+    @Test
+    public void testGetTerminalWidthWindowsInternational() {
+        String sttyResult = "\n" +
+                "Status von Gerät CON:\n" +
+                "---------------------\n" +
+                "    Zeilen:          9001\n" +
+                "    Spalten:         113\n" +
+                "    Wiederholrate:   31\n" +
+                "    Verzögerungszeit:1\n" +
+                "    Codepage:        850\n" +
+                "\n";
+        Pattern pattern = Pattern.compile(".*?:\\s*(\\d+)\\D.*?:\\s*(\\d+)\\D.*", Pattern.DOTALL);
         Matcher matcher = pattern.matcher(sttyResult);
         assertTrue(matcher.matches());
         assertEquals(113, Integer.parseInt(matcher.group(2)));


### PR DESCRIPTION
* changed terminal width detection regex pattern for Windows
* check for process termination in order to fail faster