### PR TITLE
Added Case-insensitive support for Option and related ParseResult, also with some test cases

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -6588,17 +6588,41 @@ public class CommandLine {
 
             static OptionSpec findOption(char shortName, Iterable<OptionSpec> options) {
                 for (OptionSpec option : options) {
-                    for (String name : option.names()) {
-                        if (name.length() == 2 && name.charAt(0) == '-' && name.charAt(1) == shortName) { return option; }
-                        if (name.length() == 1 && name.charAt(0) == shortName) { return option; }
+                    if(option.caseInsensitive())
+                    {
+                        char lower = Character.toLowerCase(shortName);
+                        char upper = Character.toUpperCase(shortName);
+                        for (String name : option.names()) {
+                            if (name.length() == 2 && name.charAt(0) == '-' && (name.charAt(1) == lower||name.charAt(1) == upper))
+                                return option;
+                            if (name.length() == 1 && (name.charAt(1) == lower||name.charAt(1) == upper))
+                                return option;
+                        }
+                    }else
+                    {
+                        for (String name : option.names()) {
+                            if (name.length() == 2 && name.charAt(0) == '-' && name.charAt(1) == shortName)
+                                return option;
+                            if (name.length() == 1 && name.charAt(0) == shortName)
+                                return option;
+                        }
                     }
                 }
                 return null;
             }
             static OptionSpec findOption(String name, List<OptionSpec> options) {
                 for (OptionSpec option : options) {
-                    for (String prefixed : option.names()) {
-                        if (prefixed.equals(name) || stripPrefix(prefixed).equals(name)) { return option; }
+                    if(option.caseInsensitive()) {
+                        for (String prefixed : option.names()) {
+                            if (prefixed.equalsIgnoreCase(name) || stripPrefix(prefixed).equalsIgnoreCase(name))
+                                return option;
+                        }
+                    }
+                    else {
+                        for (String prefixed : option.names()) {
+                            if (prefixed.equals(name) || stripPrefix(prefixed).equals(name))
+                                return option;
+                        }
                     }
                 }
                 return null;

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -6595,7 +6595,7 @@ public class CommandLine {
                         for (String name : option.names()) {
                             if (name.length() == 2 && name.charAt(0) == '-' && (name.charAt(1) == lower||name.charAt(1) == upper))
                                 return option;
-                            if (name.length() == 1 && (name.charAt(1) == lower||name.charAt(1) == upper))
+                            if (name.length() == 1 && (name.charAt(0) == lower || name.charAt(0)==upper))
                                 return option;
                         }
                     }else

--- a/src/test/java/picocli/OptionCaseInsensitiveTest.java
+++ b/src/test/java/picocli/OptionCaseInsensitiveTest.java
@@ -6,8 +6,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.concurrent.Callable;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class OptionCaseInsensitiveTest
 {
@@ -20,8 +19,20 @@ public class OptionCaseInsensitiveTest
         public boolean help;
         @CommandLine.Option(names = {"-a", "--take_abs"}, arity = "0..1", description = "take abs vals and add, default disabled")
         public boolean abs;
-        @CommandLine.Option(names = {"-t", "--test_flag"}, arity = "0..1", description = "just for test",negatable = true,caseInsensitive = true)
+        @CommandLine.Option(names = {"-t", "--test_flag"}, arity = "0..1", description = "just for test", negatable = true, caseInsensitive = true)
         public boolean flag;
+        @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+        Exclusive exclusive;
+
+        static class Exclusive
+        {
+            @CommandLine.Option(names = "-x", required = true, caseInsensitive = true)
+            int x;
+            @CommandLine.Option(names = "-y", required = true)
+            int y;
+            @CommandLine.Option(names = "-z", required = true)
+            int z;
+        }
 
 
         public Integer call() throws Exception
@@ -54,15 +65,16 @@ public class OptionCaseInsensitiveTest
     {
         Adder a = new Adder();
         CommandLine cmd = new CommandLine(a);
-        cmd.execute("-t","1","2");
+        cmd.execute("-t", "1", "2");
         assertTrue(a.flag);
-        cmd.execute("--no-test_flag","1","2");
+        cmd.execute("--no-test_flag", "1", "2");
         assertFalse(a.flag);
-        cmd.execute("-t","1","2");
+        cmd.execute("-t", "1", "2");
         assertTrue(a.flag);
-        cmd.execute("--nO-tEst_fLag","1","2");
+        cmd.execute("--nO-tEst_fLag", "1", "2");
         assertFalse(a.flag);
     }
+
     @Test
     public void testMixCaseSensitivityPosixOptions1()
     {
@@ -98,6 +110,15 @@ public class OptionCaseInsensitiveTest
             public int value2;
         }
         new CommandLine(new DuplicateOptions());
+    }
+
+    @Test
+    public void argGroupTest()
+    {
+        Adder a = new Adder();
+        CommandLine cmd = new CommandLine(a);
+        cmd.execute("-X=1","1","2");
+        assertEquals(1, a.exclusive.x);
     }
 
 //    @Test

--- a/src/test/java/picocli/OptionCaseInsensitiveTest.java
+++ b/src/test/java/picocli/OptionCaseInsensitiveTest.java
@@ -1,0 +1,108 @@
+package picocli;
+
+import org.junit.Test;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.concurrent.Callable;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class OptionCaseInsensitiveTest
+{
+    @CommandLine.Command(name = "adder", aliases = "addr", description = "add two integers and give result")
+    public static class Adder implements Callable<Integer>
+    {
+        @CommandLine.Parameters(paramLabel = "Integers", description = "Integers to add")
+        public int[] integers;
+        @CommandLine.Option(names = {"-h", "--help"}, usageHelp = true, description = "just a simple adder", caseInsensitive = true)
+        public boolean help;
+        @CommandLine.Option(names = {"-a", "--take_abs"}, arity = "0..1", description = "take abs vals and add, default disabled")
+        public boolean abs;
+        @CommandLine.Option(names = {"-t", "--test_flag"}, arity = "0..1", description = "just for test")
+        public boolean flag;
+
+
+        public Integer call() throws Exception
+        {
+            if (abs)
+            {
+                for (int i = 0; i < integers.length; i++)
+                    integers[i] = Math.abs(integers[i]);
+            }
+            int sum = 0;
+            for (int i : integers)
+                sum += i;
+            return sum;
+        }
+    }
+
+    @Test
+    public void testCaseInsensitivePosixOption()
+    {
+        Adder a = new Adder();
+        CommandLine cmd = new CommandLine(a);
+        StringWriter sw = new StringWriter();
+        cmd.setOut(new PrintWriter(sw));
+        cmd.execute("-H", "1", "2");
+        assertTrue(a.help);
+    }
+
+    @Test
+    public void testMixCaseSensitivityPosixOptions1()
+    {
+        Adder a = new Adder();
+        CommandLine cmd = new CommandLine(a);
+        StringWriter sw = new StringWriter();
+        cmd.setOut(new PrintWriter(sw));
+        cmd.execute("-tH", "1", "2");
+        assertTrue(a.help);
+        assertTrue(a.flag);
+    }
+
+    @Test
+    public void testCaseInsensitiveOption()
+    {
+        Adder a = new Adder();
+        CommandLine cmd = new CommandLine(a);
+        StringWriter sw = new StringWriter();
+        cmd.setOut(new PrintWriter(sw));
+        cmd.execute("--HeLp", "1", "2");
+        assertTrue(a.help);
+    }
+
+    @Test(expected = CommandLine.DuplicateOptionAnnotationsException.class)
+    public void testDuplicateOptionsAreRejected()
+    {
+        /** Duplicate parameter names are invalid. */
+        class DuplicateOptions
+        {
+            @CommandLine.Option(names = "-dUpLicate", caseInsensitive = true)
+            public int value1;
+            @CommandLine.Option(names = "-dupliCaTe", caseInsensitive = false)
+            public int value2;
+        }
+        new CommandLine(new DuplicateOptions());
+    }
+
+//    @Test
+//    public void testDuplicateNegatedOptionsRejected()
+//    {
+//        @CommandLine.Command(name = "negatable-options-demo")
+//        class NegatableOptionsDemo
+//        {
+//            @CommandLine.Option(names = "--verbose", negatable = true)
+//            boolean verbose= false;
+//            @CommandLine.Option(names = "--no-verbose")
+//            boolean nverbose = false;
+//        }
+//        NegatableOptionsDemo d = new NegatableOptionsDemo();
+//        CommandLine cmd = new CommandLine(d);
+//        cmd.execute("--verbose");
+//        assertTrue(d.verbose);
+//        cmd.execute("--no-verbose");
+//        assertFalse(d.verbose);
+//        assertTrue(d.nverbose);
+//    }
+}

--- a/src/test/java/picocli/OptionCaseInsensitiveTest.java
+++ b/src/test/java/picocli/OptionCaseInsensitiveTest.java
@@ -20,7 +20,7 @@ public class OptionCaseInsensitiveTest
         public boolean help;
         @CommandLine.Option(names = {"-a", "--take_abs"}, arity = "0..1", description = "take abs vals and add, default disabled")
         public boolean abs;
-        @CommandLine.Option(names = {"-t", "--test_flag"}, arity = "0..1", description = "just for test")
+        @CommandLine.Option(names = {"-t", "--test_flag"}, arity = "0..1", description = "just for test",negatable = true,caseInsensitive = true)
         public boolean flag;
 
 
@@ -49,6 +49,20 @@ public class OptionCaseInsensitiveTest
         assertTrue(a.help);
     }
 
+    @Test
+    public void testCaseInsensitiveNegatble()
+    {
+        Adder a = new Adder();
+        CommandLine cmd = new CommandLine(a);
+        cmd.execute("-t","1","2");
+        assertTrue(a.flag);
+        cmd.execute("--no-test_flag","1","2");
+        assertFalse(a.flag);
+        cmd.execute("-t","1","2");
+        assertTrue(a.flag);
+        cmd.execute("--nO-tEst_fLag","1","2");
+        assertFalse(a.flag);
+    }
     @Test
     public void testMixCaseSensitivityPosixOptions1()
     {


### PR DESCRIPTION
Added `@caseInsensitve` annotation to `Option`.

Added proxy classes to specially handle method requests(`put()`, `containsKey()`, etc.) to `optionsByNameMap`, `negatedOptionsByNameMap` and `posixOptionsByKeyMap` in `CommandSpec` so that logics of codes that access these three `Map` can be left unmodified.

Also, in `CommandSpec`, added codes that specially handle finding case-insensitive options in `findOption()`, so that codes in `ParseResult` can be left unmodified while still provide case-insensitive support.