### PR TITLE
Add experimental support for repeatable ArgGroup positional parameters (#1027)

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -12453,7 +12453,12 @@ public class CommandLine {
                 int localPosition = getPosition(positionalParam);
                 if (positionalParam.group() != null) { // does the positionalParam's index range contain the current position in the currently matching group
                     GroupMatchContainer groupMatchContainer = parseResultBuilder.groupMatchContainer.findOrCreateMatchingGroup(positionalParam, commandSpec.commandLine());
-                    if (!indexRange.contains(localPosition) || (groupMatchContainer != null && groupMatchContainer.lastMatch().hasMatchedValueAtPosition(positionalParam, localPosition))) {
+                    int argGroupPosition = localPosition;
+                    if (groupMatchContainer != null) {
+                        int groupArgCount = positionalParam.group().argCount();
+                        argGroupPosition %= groupArgCount;
+                    }
+                    if (!indexRange.contains(argGroupPosition) || (groupMatchContainer != null && groupMatchContainer.lastMatch().hasMatchedValueAtPosition(positionalParam, localPosition))) {
                         continue;
                     }
                 } else {

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -12453,11 +12453,8 @@ public class CommandLine {
                 int localPosition = getPosition(positionalParam);
                 if (positionalParam.group() != null) { // does the positionalParam's index range contain the current position in the currently matching group
                     GroupMatchContainer groupMatchContainer = parseResultBuilder.groupMatchContainer.findOrCreateMatchingGroup(positionalParam, commandSpec.commandLine());
-                    int argGroupPosition = localPosition;
-                    if (groupMatchContainer != null) {
-                        int groupArgCount = positionalParam.group().argCount();
-                        argGroupPosition %= groupArgCount;
-                    }
+                    int groupArgCount = positionalParam.group().argCount();
+                    int argGroupPosition = localPosition % groupArgCount;
                     if (!indexRange.contains(argGroupPosition) || (groupMatchContainer != null && groupMatchContainer.lastMatch().hasMatchedValueAtPosition(positionalParam, localPosition))) {
                         continue;
                     }

--- a/src/test/java/picocli/ArgGroupTest.java
+++ b/src/test/java/picocli/ArgGroupTest.java
@@ -3436,7 +3436,7 @@ public class ArgGroupTest {
                 return false;
             }
             StudentGrade that = (StudentGrade) o;
-            return name.equals(((StudentGrade) o).name) && grade.equals(((StudentGrade) o).grade);
+            return name.equals(that.name) && grade.equals(that.grade);
         }
 
         @Override

--- a/src/test/java/picocli/ArgGroupTest.java
+++ b/src/test/java/picocli/ArgGroupTest.java
@@ -3426,9 +3426,28 @@ public class ArgGroupTest {
             this.name = name;
             this.grade = grade;
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            StudentGrade that = (StudentGrade) o;
+            return name.equals(((StudentGrade) o).name) && grade.equals(((StudentGrade) o).grade);
+        }
+
+        @Override
+        public String toString() {
+            return "StudentGrade{" +
+                    "name='" + name + '\'' +
+                    ", grade=" + grade +
+                    '}';
+        }
     }
 
-    @Ignore("requires https://github.com/remkop/picocli/issues/1027")
     @Test // https://github.com/remkop/picocli/issues/1027
     public void testIssue1027RepeatingPositionalParams() {
         class Issue1027 {

--- a/src/test/java/picocli/ArgGroupTest.java
+++ b/src/test/java/picocli/ArgGroupTest.java
@@ -3466,6 +3466,40 @@ public class ArgGroupTest {
     }
 
     @Test // https://github.com/remkop/picocli/issues/1027
+    public void testIssue1027RepeatingPositionalParamsEdgeCase1() {
+        class Issue1027 {
+            @ArgGroup(exclusive = false, multiplicity = "4..*")
+            List<StudentGrade> gradeList;
+        }
+
+        Issue1027 bean = new Issue1027();
+        new CommandLine(bean).parseArgs("Abby 4.0 Billy 3.5 Caily 3.5 Danny 4.0".split(" "));
+
+        assertEquals(4, bean.gradeList.size());
+        assertEquals(new StudentGrade("Abby", "4.0"), bean.gradeList.get(0));
+        assertEquals(new StudentGrade("Billy", "3.5"), bean.gradeList.get(1));
+        assertEquals(new StudentGrade("Caily", "3.5"), bean.gradeList.get(2));
+        assertEquals(new StudentGrade("Danny", "4.0"), bean.gradeList.get(3));
+    }
+
+    @Test // https://github.com/remkop/picocli/issues/1027
+    public void testIssue1027RepeatingPositionalParamsEdgeCase2() {
+        class Issue1027 {
+            @ArgGroup(exclusive = false, multiplicity = "1..4")
+            List<StudentGrade> gradeList;
+        }
+
+        Issue1027 bean = new Issue1027();
+        new CommandLine(bean).parseArgs("Abby 4.0 Billy 3.5 Caily 3.5 Danny 4.0".split(" "));
+
+        assertEquals(4, bean.gradeList.size());
+        assertEquals(new StudentGrade("Abby", "4.0"), bean.gradeList.get(0));
+        assertEquals(new StudentGrade("Billy", "3.5"), bean.gradeList.get(1));
+        assertEquals(new StudentGrade("Caily", "3.5"), bean.gradeList.get(2));
+        assertEquals(new StudentGrade("Danny", "4.0"), bean.gradeList.get(3));
+    }
+
+    @Test // https://github.com/remkop/picocli/issues/1027
     public void testIssue1027RepeatingPositionalParamsWithMinMultiplicity() {
         class Issue1027 {
             @ArgGroup(exclusive = false, multiplicity = "4..*")


### PR DESCRIPTION
This is a very simple draft to fix #1027, and does not break any previous tests.

Could anyone check whether any behaviour breaks with this?