### PR TITLE
Fix issue #1048

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -2026,11 +2026,6 @@ public class CommandLine {
             this.colorScheme = colorScheme;
         }
 
-        public ColorSchemedStringWriter(int initialSize, Help.ColorScheme colorScheme) {
-            super(initialSize);
-            this.colorScheme = colorScheme;
-        }
-
         @Override
         public void write(String str, int off, int len) {
             List<IStyle> styles = str.startsWith("\t") ? colorScheme.stackTraceStyles() : colorScheme.errorStyles();

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -2009,7 +2009,6 @@ public class CommandLine {
      */
     private static String exceptionToColorString(Exception ex, Help.ColorScheme existingColorScheme){
         Help.ColorScheme colorScheme = new Help.ColorScheme.Builder(existingColorScheme).applySystemProperties().build();
-        String newLine = System.getProperty("line.separator");
         StringWriter stringWriter = new ColorSchemedStringWriter(colorScheme);
         ex.printStackTrace(new PrintWriter(stringWriter));
         return stringWriter.toString();

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -2007,7 +2007,7 @@ public class CommandLine {
      * @param existingColorScheme the {@code ColorScheme} to use
      * @return converted and colored {@code String}
      */
-    private static String exceptionToColorString(Exception ex, Help.ColorScheme existingColorScheme){
+    private static String exceptionToColorString(Exception ex, Help.ColorScheme existingColorScheme) {
         Help.ColorScheme colorScheme = new Help.ColorScheme.Builder(existingColorScheme).applySystemProperties().build();
         StringWriter stringWriter = new ColorSchemedStringWriter(colorScheme);
         ex.printStackTrace(new PrintWriter(stringWriter));
@@ -2033,21 +2033,9 @@ public class CommandLine {
 
         @Override
         public void write(String str, int off, int len) {
-            if(str.startsWith("\t")){
-                // that's stacktrace
-                super.write(Style.on(colorScheme.stackTraceStyles().toArray(new IStyle[0])));
-            } else {
-                super.write(Style.on(colorScheme.errorStyles().toArray(new IStyle[0])));
-            }
-            super.write(str, off, len);
-            if(str.startsWith("\t")){
-                super.write(Style.off(colorScheme.stackTraceStyles().toArray(new IStyle[0])));
-            } else {
-                super.write(Style.off(reverseArray(colorScheme.errorStyles().toArray(new IStyle[0]))));
-            }
-            super.write(Style.reset.off());
+            List<IStyle> styles = str.startsWith("\t") ? colorScheme.stackTraceStyles() : colorScheme.errorStyles();
+            super.write(colorScheme.apply(str.substring(off, len), styles).toString());
         }
-
     }
 
     private <T> T enrichForBackwardsCompatibility(T obj) {

--- a/src/test/java/picocli/ColorSchemeTest.java
+++ b/src/test/java/picocli/ColorSchemeTest.java
@@ -4,6 +4,11 @@ import org.junit.Test;
 import picocli.CommandLine.Help;
 import picocli.CommandLine.Help.ColorScheme;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.StringWriter;
+import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -150,6 +155,102 @@ public class ColorSchemeTest {
     }
 
     @Test
+    public void testColorScheme_singleException() throws UnsupportedEncodingException {
+        @CommandLine.Command
+        class App implements Runnable{
+            public void run() {
+                throw new RuntimeException("This is a runtime exception");
+            }
+        }
+
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream baos = new ByteArrayOutputStream(2500);
+        System.setErr(new PrintStream(baos));
+
+        final String PROPERTY = "picocli.ansi";
+        String old = System.getProperty(PROPERTY);
+        System.setProperty(PROPERTY, "true");
+
+        CommandLine commandLine = new CommandLine(new App());
+        commandLine.execute(new String[0]);
+        ColorScheme colorScheme = commandLine.getColorScheme();
+
+        System.setErr(originalErr);
+
+        String actual = new String(baos.toByteArray(), "UTF8");
+        String[] outputs = actual.split(System.getProperty("line.separator"));
+
+        final String exceptionMessage = "java.lang.RuntimeException: This is a runtime exception";
+        final String stackTraceFirstLine = "\tat picocli.ColorSchemeTest$1App.run";
+        final String stackTraceANSIStart = Help.Ansi.Style.on(colorScheme.stackTraceStyles().toArray(new Help.Ansi.Style[0]));
+        final String stackTraceFirstLineWithANSIStart = stackTraceANSIStart + stackTraceFirstLine;
+
+        assertEquals(colorScheme.errorText(exceptionMessage).toString(), outputs[0]);
+        assertEquals(stackTraceFirstLineWithANSIStart, outputs[1].substring(0, stackTraceFirstLineWithANSIStart.length()));
+
+        if(old == null){
+            System.clearProperty(PROPERTY);
+        } else {
+            System.setProperty(PROPERTY, old);
+        }
+    }
+
+    @Test
+    public void testColorScheme_nestedException() throws UnsupportedEncodingException {
+        @CommandLine.Command
+        class App implements Runnable{
+            public void run() {
+                Exception e1 = new RuntimeException("Root Cause");
+                Exception e2 = new RuntimeException("Inner Exception", e1);
+                throw new RuntimeException("Outer Exception", e2);
+            }
+        }
+
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream baos = new ByteArrayOutputStream(2500);
+        System.setErr(new PrintStream(baos));
+
+        final String PROPERTY = "picocli.ansi";
+        String old = System.getProperty(PROPERTY);
+        System.setProperty(PROPERTY, "true");
+
+        CommandLine commandLine = new CommandLine(new App());
+        commandLine.execute(new String[0]);
+        ColorScheme colorScheme = commandLine.getColorScheme();
+
+        System.setErr(originalErr);
+
+        String actual = new String(baos.toByteArray(), "UTF8");
+        String[] outputs = actual.split(System.getProperty("line.separator"));
+
+        final String[] exceptionMessages = new String[]{"java.lang.RuntimeException: Outer Exception",
+                "Caused by: java.lang.RuntimeException: Inner Exception",
+                "Caused by: java.lang.RuntimeException: Root Cause"};
+
+        final String exceptionANSIStart = Help.Ansi.Style.on(colorScheme.errorStyles().toArray(new Help.Ansi.Style[0]));
+
+        int foundExceptionMessageCount = 0;
+        for (String line : outputs) {
+            if(line.startsWith(exceptionANSIStart + exceptionMessages[foundExceptionMessageCount])){
+                foundExceptionMessageCount++;
+
+                if(foundExceptionMessageCount==3){
+                    break;
+                }
+            }
+        }
+
+        assertEquals(3, foundExceptionMessageCount);
+
+        if(old == null){
+            System.clearProperty(PROPERTY);
+        } else {
+            System.setProperty(PROPERTY, old);
+        }
+    }
+
+
+    @Test
     public void testColorSchemeBuilder_customMarkupMapInitiallyNull() {
         ColorScheme.Builder builder = new ColorScheme.Builder();
         assertNull(builder.customMarkupMap());
@@ -175,4 +276,6 @@ public class ColorSchemeTest {
         assertNotSame(original.customMarkupMap(), builder.customMarkupMap());
         assertNotSame(map, builder.customMarkupMap());
     }
+
+
 }

--- a/src/test/java/picocli/ExecuteTest.java
+++ b/src/test/java/picocli/ExecuteTest.java
@@ -481,7 +481,9 @@ public class ExecuteTest {
         int exitCode = cmd.execute();
         assertEquals(1234, exitCode);
 
-        assertThat(this.systemErrRule.getLog(), startsWith("java.io.IOException: error"));
+        assertThat(this.systemErrRule.getLog(), startsWith(Help.Ansi.ON.new Text(format(
+                "@|fg(red),bold java.io.IOException: error|@"
+        )).toString()));
         assertThat(this.systemErrRule.getLog(), containsString("java.lang.IllegalStateException: test exception"));
     }
 
@@ -489,7 +491,7 @@ public class ExecuteTest {
     public void testExecuteCallableThrowsException() {
         int exitCode = new CommandLine(new MyCallable()).execute("-x", "abc");
         String cmd = "mycmd";
-        String msg = "java.lang.IllegalStateException: this is a test";
+        String msg = EXCEPTION_MESSAGE_ANSI;
         assertTrue(systemErrRule.getLog().startsWith(msg));
         assertEquals(ExitCode.SOFTWARE, exitCode);
     }
@@ -527,13 +529,17 @@ public class ExecuteTest {
         assertEquals(MYCALLABLE_USAGE_ANSI, sw.toString());
     }
 
+    private static final String EXCEPTION_MESSAGE_ANSI = Help.Ansi.ON.new Text(format(
+            "@|fg(red),bold java.lang.IllegalStateException: this is a test|@"
+    )).toString();
+
     @Test
     public void testCallWithFactory() {
         StringWriter sw = new StringWriter();
         int exitCode = new CommandLine(MyCallable.class, new InnerClassFactory(this))
                 .setErr(new PrintWriter(sw)).execute("-x", "a");
         assertEquals(ExitCode.SOFTWARE, exitCode);
-        assertThat(sw.toString(), startsWith("java.lang.IllegalStateException: this is a test"));
+        assertThat(sw.toString(), startsWith(EXCEPTION_MESSAGE_ANSI));
     }
 
     @Test
@@ -542,7 +548,7 @@ public class ExecuteTest {
         int exitCode = new CommandLine(MyRunnable.class, new InnerClassFactory(this))
                 .setErr(new PrintWriter(sw)).execute("-x", "a");
         assertEquals(ExitCode.SOFTWARE, exitCode);
-        assertThat(sw.toString(), startsWith("java.lang.IllegalStateException: this is a test"));
+        assertThat(sw.toString(), startsWith(EXCEPTION_MESSAGE_ANSI));
     }
 
     @Test
@@ -596,7 +602,9 @@ public class ExecuteTest {
         }
         StringWriter sw = new StringWriter();
         assertEquals(ExitCode.SOFTWARE, new CommandLine(new App()).setErr(new PrintWriter(sw)).execute());
-        assertThat(sw.toString(), startsWith("picocli.CommandLine$ExecutionException: abc"));
+        assertThat(sw.toString(), startsWith(Help.Ansi.ON.new Text(format(
+                "@|fg(red),bold picocli.CommandLine$ExecutionException: abc|@"
+        )).toString()));
     }
 
     @Test
@@ -610,7 +618,9 @@ public class ExecuteTest {
         }
         StringWriter sw = new StringWriter();
         assertEquals(ExitCode.SOFTWARE, new CommandLine(new App()).setErr(new PrintWriter(sw)).execute());
-        assertThat(sw.toString(), startsWith("picocli.CommandLine$ExecutionException: abc"));
+        assertThat(sw.toString(), startsWith(Help.Ansi.ON.new Text(format(
+                "@|fg(red),bold picocli.CommandLine$ExecutionException: abc|@"
+        )).toString()));
     }
 
     @Test
@@ -646,9 +656,10 @@ public class ExecuteTest {
         CommandLine cmd = new CommandLine(new App()).setExecutionStrategy(new FailingExecutionStrategy());
         assertEquals(ExitCode.SOFTWARE, cmd.execute());
 
-        String prefix = String.format("" +
-                "java.lang.IllegalArgumentException: abc%n" +
-                "\tat picocli.ExecuteTest$1FailingExecutionStrategy.execute(ExecuteTest.java");
+        String prefix = Help.Ansi.ON.new Text(format("" +
+                "@|fg(red),bold java.lang.IllegalArgumentException: abc|@%n" +
+                "@|italic \tat picocli.ExecuteTest$1FailingExecutionStrategy.execute(ExecuteTest.java|@")).toString();
+        prefix = prefix.substring(0, prefix.length() - Help.Ansi.Style.off(new Help.Ansi.IStyle[]{Help.Ansi.Style.italic, Help.Ansi.Style.reset}).length());
         assertTrue(systemErrRule.getLog().startsWith(prefix));
     }
 
@@ -805,9 +816,11 @@ public class ExecuteTest {
         cmd.setParameterExceptionHandler(pah);
         int exitCode = cmd.execute("-x");
         assertEquals(ExitCode.USAGE, exitCode);
-        String expected = String.format("" +
-                "java.lang.IllegalStateException: blah%n" +
-                "\tat %s.handleParseException(", pah.getClass().getName());
+        String expected = String.format(Help.Ansi.ON.new Text(format("" +
+                "@|fg(red),bold java.lang.IllegalStateException: blah|@%n" +
+                "@|italic \tat %s.handleParseException(|@", pah.getClass().getName())).toString());
+        expected = expected.substring(0, expected.length() - Help.Ansi.Style.off(new Help.Ansi.IStyle[]{Help.Ansi.Style.italic, Help.Ansi.Style.reset}).length());
+
         assertTrue(systemErrRule.getLog().startsWith(expected));
         assertEquals("", systemOutRule.getLog());
     }

--- a/src/test/java/picocli/ExecuteTest.java
+++ b/src/test/java/picocli/ExecuteTest.java
@@ -481,9 +481,7 @@ public class ExecuteTest {
         int exitCode = cmd.execute();
         assertEquals(1234, exitCode);
 
-        assertThat(this.systemErrRule.getLog(), startsWith(Help.Ansi.ON.new Text(format(
-                "@|fg(red),bold java.io.IOException: error|@"
-        )).toString()));
+        assertThat(this.systemErrRule.getLog(), startsWith("java.io.IOException: error"));
         assertThat(this.systemErrRule.getLog(), containsString("java.lang.IllegalStateException: test exception"));
     }
 
@@ -491,7 +489,7 @@ public class ExecuteTest {
     public void testExecuteCallableThrowsException() {
         int exitCode = new CommandLine(new MyCallable()).execute("-x", "abc");
         String cmd = "mycmd";
-        String msg = EXCEPTION_MESSAGE_ANSI;
+        String msg = "java.lang.IllegalStateException: this is a test";
         assertTrue(systemErrRule.getLog().startsWith(msg));
         assertEquals(ExitCode.SOFTWARE, exitCode);
     }
@@ -529,17 +527,13 @@ public class ExecuteTest {
         assertEquals(MYCALLABLE_USAGE_ANSI, sw.toString());
     }
 
-    private static final String EXCEPTION_MESSAGE_ANSI = Help.Ansi.ON.new Text(format(
-            "@|fg(red),bold java.lang.IllegalStateException: this is a test|@"
-    )).toString();
-
     @Test
     public void testCallWithFactory() {
         StringWriter sw = new StringWriter();
         int exitCode = new CommandLine(MyCallable.class, new InnerClassFactory(this))
                 .setErr(new PrintWriter(sw)).execute("-x", "a");
         assertEquals(ExitCode.SOFTWARE, exitCode);
-        assertThat(sw.toString(), startsWith(EXCEPTION_MESSAGE_ANSI));
+        assertThat(sw.toString(), startsWith("java.lang.IllegalStateException: this is a test"));
     }
 
     @Test
@@ -548,7 +542,7 @@ public class ExecuteTest {
         int exitCode = new CommandLine(MyRunnable.class, new InnerClassFactory(this))
                 .setErr(new PrintWriter(sw)).execute("-x", "a");
         assertEquals(ExitCode.SOFTWARE, exitCode);
-        assertThat(sw.toString(), startsWith(EXCEPTION_MESSAGE_ANSI));
+        assertThat(sw.toString(), startsWith("java.lang.IllegalStateException: this is a test"));
     }
 
     @Test
@@ -602,9 +596,7 @@ public class ExecuteTest {
         }
         StringWriter sw = new StringWriter();
         assertEquals(ExitCode.SOFTWARE, new CommandLine(new App()).setErr(new PrintWriter(sw)).execute());
-        assertThat(sw.toString(), startsWith(Help.Ansi.ON.new Text(format(
-                "@|fg(red),bold picocli.CommandLine$ExecutionException: abc|@"
-        )).toString()));
+        assertThat(sw.toString(), startsWith("picocli.CommandLine$ExecutionException: abc"));
     }
 
     @Test
@@ -618,9 +610,7 @@ public class ExecuteTest {
         }
         StringWriter sw = new StringWriter();
         assertEquals(ExitCode.SOFTWARE, new CommandLine(new App()).setErr(new PrintWriter(sw)).execute());
-        assertThat(sw.toString(), startsWith(Help.Ansi.ON.new Text(format(
-                "@|fg(red),bold picocli.CommandLine$ExecutionException: abc|@"
-        )).toString()));
+        assertThat(sw.toString(), startsWith("picocli.CommandLine$ExecutionException: abc"));
     }
 
     @Test
@@ -656,10 +646,9 @@ public class ExecuteTest {
         CommandLine cmd = new CommandLine(new App()).setExecutionStrategy(new FailingExecutionStrategy());
         assertEquals(ExitCode.SOFTWARE, cmd.execute());
 
-        String prefix = Help.Ansi.ON.new Text(format("" +
-                "@|fg(red),bold java.lang.IllegalArgumentException: abc|@%n" +
-                "@|italic \tat picocli.ExecuteTest$1FailingExecutionStrategy.execute(ExecuteTest.java|@")).toString();
-        prefix = prefix.substring(0, prefix.length() - Help.Ansi.Style.off(new Help.Ansi.IStyle[]{Help.Ansi.Style.italic, Help.Ansi.Style.reset}).length());
+        String prefix = String.format("" +
+                "java.lang.IllegalArgumentException: abc%n" +
+                "\tat picocli.ExecuteTest$1FailingExecutionStrategy.execute(ExecuteTest.java");
         assertTrue(systemErrRule.getLog().startsWith(prefix));
     }
 
@@ -816,11 +805,9 @@ public class ExecuteTest {
         cmd.setParameterExceptionHandler(pah);
         int exitCode = cmd.execute("-x");
         assertEquals(ExitCode.USAGE, exitCode);
-        String expected = String.format(Help.Ansi.ON.new Text(format("" +
-                "@|fg(red),bold java.lang.IllegalStateException: blah|@%n" +
-                "@|italic \tat %s.handleParseException(|@", pah.getClass().getName())).toString());
-        expected = expected.substring(0, expected.length() - Help.Ansi.Style.off(new Help.Ansi.IStyle[]{Help.Ansi.Style.italic, Help.Ansi.Style.reset}).length());
-
+        String expected = String.format("" +
+                "java.lang.IllegalStateException: blah%n" +
+                "\tat %s.handleParseException(", pah.getClass().getName());
         assertTrue(systemErrRule.getLog().startsWith(expected));
         assertEquals("", systemOutRule.getLog());
     }


### PR DESCRIPTION
Injecting ANSI characters into ColorSchemeStringWriter, instead of reimplementing `printStackTrace()`.