### PR TITLE
Expose the expanded argument list from ParseResult

### DIFF
--- a/src/test/java/picocli/AtFileTest.java
+++ b/src/test/java/picocli/AtFileTest.java
@@ -10,6 +10,7 @@ import org.junit.rules.TestRule;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
+import picocli.CommandLine.ParseResult;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -774,5 +775,28 @@ public class AtFileTest {
                 "  -h, --help             Show this help message and exit.%n" +
                 "  -V, --version          Print version information and exit.%n");
         assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testAtFileExpandedArgsParsed() {
+        class App {
+            @Option(names = "-v")
+            private boolean verbose;
+
+            @Parameters
+            private List<String> files;
+        }
+        File file = findFile("/argfile1.txt");
+        if (!file.getAbsolutePath().startsWith(System.getProperty("user.dir"))) {
+            return;
+        }
+        String relative = file.getAbsolutePath().substring(System.getProperty("user.dir").length());
+        if (relative.startsWith(File.separator)) {
+            relative = relative.substring(File.separator.length());
+        }
+        CommandLine commandLine = new CommandLine(new App());
+        ParseResult parseResult = commandLine.parseArgs(new String[] {"@" + relative});
+
+        assertEquals(Arrays.asList("1111", "-v", "2222", ";3333"), parseResult.expandedArgs());
     }
 }


### PR DESCRIPTION
Written to solve #1074 , this exposes the expanded argument list that picocli keeps internally. I had to reverse the list since it was stored as a stack, which I believe means we're copying the full argument list twice into memory. Ideally we'd use some sort of reversed view and not duplicate it, but since we don't have guava or anything like that it's slightly ugly imo. Happy to update with that though.