### PR TITLE
fix factory used for repeatable subcommands

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -5753,7 +5753,7 @@ public class CommandLine {
 
             private CommandSpec copy() {
                 Object obj = userObject.type == null ? userObject.instance : userObject.type;
-                CommandSpec result = obj == null ? CommandSpec.create() : CommandSpec.forAnnotatedObject(obj);
+                CommandSpec result = obj == null ? CommandSpec.create() : CommandSpec.forAnnotatedObject(obj, userObject.factory);
                 result.commandLine = commandLine;
                 result.parent = parent;
                 result.methodParams = methodParams;


### PR DESCRIPTION
the factory should be passed when creating a CommandSpec copy and not degrade to the DefaultFactory