### PR TITLE
add ability to pass options via command's constructor

### DIFF
--- a/src/test/java/picocli/ConstructorInjectedOptionsTest.java
+++ b/src/test/java/picocli/ConstructorInjectedOptionsTest.java
@@ -1,0 +1,49 @@
+package picocli;
+
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+
+import static org.junit.Assert.assertEquals;
+import static picocli.CommandLine.*;
+
+public class ConstructorInjectedOptionsTest {
+
+  @Command
+  static class TestCommandNoArgConstructor implements Callable<Integer> {
+    public TestCommandNoArgConstructor() {
+      System.out.println("hi");
+    }
+    @Override
+    public Integer call() {
+      return 0; // success
+    }
+  }
+
+  @Test
+  public void testInvocationWithCommandArgumentAsType() {
+    int result = new CommandLine(TestCommandNoArgConstructor.class).execute();
+    assertEquals(0, result);
+  }
+
+  @Command
+  static class TestCommandWithArgConstructor implements Callable<Integer> {
+    private final int num;
+    public TestCommandWithArgConstructor(@Option(names = "-i") int num) {
+      this.num = num;
+    }
+
+    @Override
+    public Integer call() {
+      return num;
+    }
+  }
+
+  @Test
+  public void testInvocationWithCommandArgumentAsTypeWithArg() {
+    CommandLine commandLine = new CommandLine(TestCommandWithArgConstructor.class);
+    int result = commandLine.execute("-i", "42");
+    assertEquals(42, result);
+  }
+}
+


### PR DESCRIPTION
hi remko,
  i'd like you to review this commit.
  the intent here is to support passing options via the constructor.

  i don't think it should be merged as is, without your review and perhaps some tweaks, as i don't fully understand all the magic that picocli does.

  this code change causes one of the subcommandtests to fail, but i hope that's something that's easily rectified.

  i definitely need to spend more time understanding the code.

  my main reflection at the moment is that i suspect spring does similar work when it builds application contexts.  i wonder if this project can leverage the same utilities that spring uses to build the command object, leveraging autowiring, constructor and setter injection so we don't have to.