### PR TITLE
PR: manpage generator: overcome encoding issues (#1109)

### DIFF
--- a/picocli-codegen/src/main/java/picocli/codegen/docgen/manpage/ManPageGenerator.java
+++ b/picocli-codegen/src/main/java/picocli/codegen/docgen/manpage/ManPageGenerator.java
@@ -22,8 +22,10 @@ import picocli.codegen.util.Assert;
 import picocli.codegen.util.Util;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.lang.reflect.Method;
 import java.util.*;
@@ -350,10 +352,10 @@ public class ManPageGenerator implements Callable<Integer> {
     }
 
     private static void generateSingleManPage(CommandSpec spec, File manpage) throws IOException {
-        FileWriter writer = null;
+        OutputStreamWriter writer = null;
         PrintWriter pw = null;
         try {
-            writer = new FileWriter(manpage);
+            writer = new OutputStreamWriter(new FileOutputStream(manpage), "UTF-8");
             pw = new PrintWriter(writer);
             writeSingleManPage(pw, spec);
         } finally {


### PR DESCRIPTION
I found a fairly easy way to overcome the encoding issues addressed in #1109. I guess the proposed changes should be sufficient here. Generating man pages for the [I18NDemo](https://github.com/remkop/picocli/blob/master/picocli-examples/src/main/java/picocli/examples/i18n/I18NDemo.java) given in the examples section of the repo works perfect now.
Unfortunately, the patch breaks two exiting tests and I didn't find an easy way to make them work again. Can you have a look here?
Also while not strictly necessary, I would suggest to explicitly add the encoding attribute to the generated .adoc files (second commit).
Do we need test(s) for the patch? If so, can you take over or can you bring me on the right track here? Thanks.