### PR TITLE
DOC: Fix typo in picocli user manual

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -6155,7 +6155,7 @@ public class GuiceFactory implements IFactory {
         try {
             return injector.getInstance(aClass);
         } catch (ConfigurationException ex) { // no implementation found in Guice configuration
-            return CommandLine.defaultFactory().create(clazz); // fallback if missing
+            return CommandLine.defaultFactory().create(aClass); // fallback if missing
         }
     }
 

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -6145,7 +6145,8 @@ The below example shows how to create a <<Custom Factory,custom `IFactory`>> imp
 [source,java]
 ----
 import com.google.inject.*;
-import picocli.CommandLine.IFactory;
+import picocli.*;
+import picocli.CommandLine.*;
 
 public class GuiceFactory implements IFactory {
     private final Injector injector = Guice.createInjector(new DemoModule());
@@ -6163,7 +6164,6 @@ public class GuiceFactory implements IFactory {
         @Override
         protected void configure() {
             bind(java.util.List.class).to(java.util.LinkedList.class);
-            bind(Runnable.class).to(InjectionDemo.class);
         }
     }
 }
@@ -6173,7 +6173,9 @@ Use the custom factory when creating a `CommandLine` instance, or when invoking 
 
 [source,java]
 ----
-import javax.inject.Inject;
+import javax.inject.*;
+import picocli.*;
+import picocli.CommandLine.*;
 
 @Command(name = "di-demo")
 public class InjectionDemo implements Runnable {
@@ -6182,7 +6184,7 @@ public class InjectionDemo implements Runnable {
     @Option(names = "-x") int x;
 
     public static void main(String[] args) {
-        new CommandLine(Runnable.class, new GuiceFactory()).execute(args);
+        new CommandLine(InjectionDemo.class, new GuiceFactory()).execute(args);
     }
 
     @Override

--- a/docs/index.html
+++ b/docs/index.html
@@ -9122,7 +9122,8 @@ Multi-line text blocks can be used in command and option descriptions, headers a
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="java"><span class="keyword">import</span> <span class="include">com.google.inject</span>.*;
-<span class="keyword">import</span> <span class="include">picocli.CommandLine.IFactory</span>;
+<span class="keyword">import</span> <span class="include">picocli</span>.*;
+<span class="keyword">import</span> <span class="include">picocli.CommandLine</span>.*;
 
 <span class="directive">public</span> <span class="type">class</span> <span class="class">GuiceFactory</span> <span class="directive">implements</span> IFactory {
     <span class="directive">private</span> <span class="directive">final</span> Injector injector = Guice.createInjector(<span class="keyword">new</span> DemoModule());
@@ -9140,7 +9141,6 @@ Multi-line text blocks can be used in command and option descriptions, headers a
         <span class="annotation">@Override</span>
         <span class="directive">protected</span> <span class="type">void</span> configure() {
             bind(java.util.List.class).to(java.util.LinkedList.class);
-            bind(<span class="predefined-type">Runnable</span>.class).to(InjectionDemo.class);
         }
     }
 }</code></pre>
@@ -9151,7 +9151,9 @@ Multi-line text blocks can be used in command and option descriptions, headers a
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="CodeRay highlight"><code data-lang="java"><span class="keyword">import</span> <span class="include">javax.inject.Inject</span>;
+<pre class="CodeRay highlight"><code data-lang="java"><span class="keyword">import</span> <span class="include">javax.inject</span>.*;
+<span class="keyword">import</span> <span class="include">picocli</span>.*;
+<span class="keyword">import</span> <span class="include">picocli.CommandLine</span>.*;
 
 <span class="annotation">@Command</span>(name = <span class="string"><span class="delimiter">&quot;</span><span class="content">di-demo</span><span class="delimiter">&quot;</span></span>)
 <span class="directive">public</span> <span class="type">class</span> <span class="class">InjectionDemo</span> <span class="directive">implements</span> <span class="predefined-type">Runnable</span> {
@@ -9160,7 +9162,7 @@ Multi-line text blocks can be used in command and option descriptions, headers a
     <span class="annotation">@Option</span>(names = <span class="string"><span class="delimiter">&quot;</span><span class="content">-x</span><span class="delimiter">&quot;</span></span>) <span class="type">int</span> x;
 
     <span class="directive">public</span> <span class="directive">static</span> <span class="type">void</span> main(<span class="predefined-type">String</span><span class="type">[]</span> args) {
-        <span class="keyword">new</span> CommandLine(<span class="predefined-type">Runnable</span>.class, <span class="keyword">new</span> GuiceFactory()).execute(args);
+        <span class="keyword">new</span> CommandLine(InjectionDemo.class, <span class="keyword">new</span> GuiceFactory()).execute(args);
     }
 
     <span class="annotation">@Override</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -9132,7 +9132,7 @@ Multi-line text blocks can be used in command and option descriptions, headers a
         <span class="keyword">try</span> {
             <span class="keyword">return</span> injector.getInstance(aClass);
         } <span class="keyword">catch</span> (<span class="exception">ConfigurationException</span> ex) { <span class="comment">// no implementation found in Guice configuration</span>
-            <span class="keyword">return</span> CommandLine.defaultFactory().create(clazz); <span class="comment">// fallback if missing</span>
+            <span class="keyword">return</span> CommandLine.defaultFactory().create(aClass); <span class="comment">// fallback if missing</span>
         }
     }
 


### PR DESCRIPTION
I found a typo in the "Guice Example".

- The method variable name of `GuiceFactory#create` is `aClass`.
- I think the 1st argument of `new CommandLine` should have annotations of picocli, so we should specify a implemented class (i.e. `InjectionDemo.class`) not `Runnable.class`
- If we specify the implemented class, bind definition for `Runnable.class` might not be unnecessary.