### PR TITLE
Fix #1156, make HelpCommand respect subcommands case-sensitivity and abbreviation

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -13942,12 +13942,13 @@ public class CommandLine {
             if (parent == null) { return; }
             Help.ColorScheme colors = colorScheme != null ? colorScheme : Help.defaultColorScheme(ansi);
             if (commands.length > 0) {
+                Map<String, CommandLine> parentSubcommands = parent.getCommandSpec().subcommands();
                 String fullName = commands[0];
                 if (parent.isAbbreviatedSubcommandsAllowed()) {
-                    fullName = AbbreviationMatcher.match(parent.getCommandSpec().subcommands().keySet(), commands[0],
-                            parent.getCommandSpec().subcommandsCaseInsensitive(), self);
+                    fullName = AbbreviationMatcher.match(parentSubcommands.keySet(), fullName,
+                            parent.isSubcommandsCaseInsensitive(), self);
                 }
-                CommandLine subcommand = parent.getCommandSpec().subcommands().get(fullName);
+                CommandLine subcommand = parentSubcommands.get(fullName);
                 if (subcommand != null) {
                     if (outWriter != null) {
                         subcommand.usage(outWriter, colors);

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -365,10 +365,7 @@ public class CommandLine {
      * @since 0.9.7
      */
     public Map<String, CommandLine> getSubcommands() {
-        CaseAwareLinkedMap<String, CommandLine> subcommands = new CaseAwareLinkedMap<String, CommandLine>();
-        subcommands.setCaseInsensitive(isSubcommandsCaseInsensitive());
-        subcommands.putAll(getCommandSpec().subcommands());
-        return subcommands;
+        return new CaseAwareLinkedMap<String, CommandLine>(getCommandSpec().commands);
     }
     /**
      * Returns the command that this is a subcommand of, or {@code null} if this is a top-level command.
@@ -5580,14 +5577,15 @@ public class CommandLine {
             }
 
             /**
-             * Constructs a {@code CaseAwareLinkedMap} instance with the same mappings as the specified map.
-             * The {@code CaseAwareLinkedMap} instance is created with a default locale {@link java.util.Locale#ENGLISH}.
-             * @param map the map whose mappings are to be placed in this map
+             * Constructs a {@code CaseAwareLinkedMap} instance with the same mappings, case-sensitivity and locale as the specified map.
+             * @param map the map whose mappings, case-sensitivity and locale are to be placed in this map
              * @throws NullPointerException if the specified map is null
              */
-            public CaseAwareLinkedMap(Map<? extends K, ? extends V> map) {
-                this(ENGLISH);
-                putAll(map);
+            public CaseAwareLinkedMap(CaseAwareLinkedMap<? extends K, ? extends V> map) {
+                this.targetMap.putAll(map.targetMap);
+                this.keyMap.putAll(map.keyMap);
+                this.caseInsensitive = map.caseInsensitive;
+                this.locale = map.locale;
             }
 
             static boolean isCaseConvertible(Class<?> clazz) {

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -5625,6 +5625,11 @@ public class CommandLine {
                 this.caseInsensitive = caseInsensitive;
             }
 
+            /** Returns the locale of the map. */
+            public Locale getLocale() {
+                return locale;
+            }
+
             /**
              * Returns the case-sensitive key of the specified case-insensitive key if {@code isCaseSensitive()}.
              * Otherwise, the specified case-insensitive key is returned.

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -365,8 +365,7 @@ public class CommandLine {
      * @since 0.9.7
      */
     public Map<String, CommandLine> getSubcommands() {
-        return new CaseAwareLinkedMap<String, CommandLine>(
-                (CaseAwareLinkedMap<String, CommandLine>) getCommandSpec().subcommands());
+        return new CaseAwareLinkedMap<String, CommandLine>(getCommandSpec().subcommands());
     }
     /**
      * Returns the command that this is a subcommand of, or {@code null} if this is a top-level command.
@@ -5563,14 +5562,14 @@ public class CommandLine {
             private final Locale locale;
 
             /**
-             * Constructs an empty LinkedCaseAwareMap instance with {@link java.util.Locale#ENGLISH}.
+             * Constructs an empty {@code CaseAwareLinkedMap} instance with {@link java.util.Locale#ENGLISH}.
              */
             public CaseAwareLinkedMap() {
                 this(ENGLISH);
             }
 
             /**
-             * Constructs an empty LinkedCaseAwareMap instance with the specified {@link java.util.Locale}.
+             * Constructs an empty {@code CaseAwareLinkedMap} instance with the specified {@link java.util.Locale}.
              * @param locale the locale to convert character cases
              */
             public CaseAwareLinkedMap(Locale locale) {
@@ -5578,16 +5577,14 @@ public class CommandLine {
             }
 
             /**
-             * Constructs a CaseAwareLinkedMap instance with the same mappings, case sensitivity and locale as the specified map.
-             * @param map the map whose mappings, case sensitivity and locale are to be placed in this map
+             * Constructs a {@code CaseAwareLinkedMap} instance with the same mappings as the specified map.
+             * The {@code CaseAwareLinkedMap} instance is created with a default locale {@link java.util.Locale#ENGLISH}.
+             * @param map the map whose mappings are to be placed in this map
              * @throws NullPointerException if the specified map is null
              */
-            public CaseAwareLinkedMap(CaseAwareLinkedMap<K, V> map) {
-                targetMap.putAll(map.targetMap);
-                keyMap.putAll(map.keyMap);
-                keySet.addAll(map.keySet);
-                caseInsensitive = map.caseInsensitive;
-                locale = map.locale;
+            public CaseAwareLinkedMap(Map<? extends K, ? extends V> map) {
+                this(ENGLISH);
+                putAll(map);
             }
 
             static boolean isCaseConvertible(Class<?> clazz) {

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -13942,7 +13942,12 @@ public class CommandLine {
             if (parent == null) { return; }
             Help.ColorScheme colors = colorScheme != null ? colorScheme : Help.defaultColorScheme(ansi);
             if (commands.length > 0) {
-                CommandLine subcommand = parent.getCommandSpec().subcommands().get(commands[0]);
+                String fullName = commands[0];
+                if (parent.isAbbreviatedSubcommandsAllowed()) {
+                    fullName = AbbreviationMatcher.match(parent.getCommandSpec().subcommands().keySet(), commands[0],
+                            parent.getCommandSpec().subcommandsCaseInsensitive(), self);
+                }
+                CommandLine subcommand = parent.getCommandSpec().subcommands().get(fullName);
                 if (subcommand != null) {
                     if (outWriter != null) {
                         subcommand.usage(outWriter, colors);

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -365,7 +365,10 @@ public class CommandLine {
      * @since 0.9.7
      */
     public Map<String, CommandLine> getSubcommands() {
-        return new CaseAwareLinkedMap<String, CommandLine>(getCommandSpec().subcommands());
+        CaseAwareLinkedMap<String, CommandLine> subcommands = new CaseAwareLinkedMap<String, CommandLine>();
+        subcommands.setCaseInsensitive(isSubcommandsCaseInsensitive());
+        subcommands.putAll(getCommandSpec().subcommands());
+        return subcommands;
     }
     /**
      * Returns the command that this is a subcommand of, or {@code null} if this is a top-level command.

--- a/src/test/java/picocli/CaseAwareLinkedMapTest.java
+++ b/src/test/java/picocli/CaseAwareLinkedMapTest.java
@@ -34,7 +34,7 @@ public class CaseAwareLinkedMapTest {
 
     @Test
     public void testCopyConstructor() {
-        Map<String, String> map = new HashMap<String, String>();
+        CaseAwareLinkedMap<String, String> map = new CaseAwareLinkedMap<String, String>();
         map.put("foo", "bar");
         map.put("FOO", "BAR");
         CaseAwareLinkedMap<String, String> copy = new CaseAwareLinkedMap<String, String>(map);

--- a/src/test/java/picocli/CaseAwareLinkedMapTest.java
+++ b/src/test/java/picocli/CaseAwareLinkedMapTest.java
@@ -7,6 +7,10 @@ import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.rules.TestRule;
 import picocli.CommandLine.Model.CaseAwareLinkedMap;
 
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
 import static org.junit.Assert.*;
 
 public class CaseAwareLinkedMapTest {
@@ -21,6 +25,24 @@ public class CaseAwareLinkedMapTest {
     @Test
     public void testDefaultCaseSensitivity() {
         assertFalse(new CaseAwareLinkedMap<String, String>().isCaseInsensitive());
+    }
+
+    @Test
+    public void testDefaultLocale() {
+        assertEquals(Locale.ENGLISH, new CaseAwareLinkedMap<String, String>().getLocale());
+    }
+
+    @Test
+    public void testCopyConstructor() {
+        Map<String, String> map = new HashMap<String, String>();
+        map.put("foo", "bar");
+        map.put("FOO", "BAR");
+        CaseAwareLinkedMap<String, String> copy = new CaseAwareLinkedMap<String, String>(map);
+        assertFalse(copy.isCaseInsensitive());
+        assertEquals(Locale.ENGLISH, copy.getLocale());
+        assertEquals(2, copy.size());
+        assertEquals("bar", copy.get("foo"));
+        assertEquals("BAR", copy.get("FOO"));
     }
 
     @Test

--- a/src/test/java/picocli/CommandLineTest.java
+++ b/src/test/java/picocli/CommandLineTest.java
@@ -1855,6 +1855,21 @@ public class CommandLineTest {
         assertTrue("cmd2", commandMap.get("cmd2").getCommand() instanceof Command2);
     }
 
+    @Test
+    public void testCommandListReturnsCaseInsensitiveRegisteredCommands() {
+        @Command class MainCommand {}
+        @Command class Command1 {}
+        @Command class Command2 {}
+        CommandLine commandLine = new CommandLine(new MainCommand());
+        commandLine.addSubcommand("cmd1", new Command1()).addSubcommand("cmd2", new Command2());
+        commandLine.setSubcommandsCaseInsensitive(true);
+
+        Map<String, CommandLine> commandMap = commandLine.getSubcommands();
+        assertEquals(2, commandMap.size());
+        assertTrue("cmd1", commandMap.get("CMD1").getCommand() instanceof Command1);
+        assertTrue("cmd2", commandMap.get("CMD2").getCommand() instanceof Command2);
+    }
+
     @Test(expected = InitializationException.class)
     public void testPopulateCommandRequiresAnnotatedCommand() {
         class App { }

--- a/src/test/java/picocli/HelpSubCommandTest.java
+++ b/src/test/java/picocli/HelpSubCommandTest.java
@@ -252,6 +252,43 @@ public class HelpSubCommandTest {
     }
 
     @Test
+    public void testHelpSubcommandWithAbbreviatedValidCommand() {
+        @Command(subcommands = {HelpTest.Sub.class, HelpCommand.class})
+        class App implements Runnable{ public void run(){}}
+
+        StringWriter sw = new StringWriter();
+        new CommandLine(new App())
+                .setOut(new PrintWriter(sw))
+                .setColorScheme(Help.defaultColorScheme(Help.Ansi.OFF))
+                .setAbbreviatedSubcommandsAllowed(true)
+                .execute("help", "s");
+
+        String expected = String.format("" +
+                "Usage: <main class> sub%n" +
+                "This is a subcommand%n");
+        assertEquals(expected, sw.toString());
+    }
+
+    @Test
+    public void testHelpSubcommandWithAbbreviatedCaseInsensitiveValidCommand() {
+        @Command(subcommands = {HelpTest.Sub.class, HelpCommand.class})
+        class App implements Runnable{ public void run(){}}
+
+        StringWriter sw = new StringWriter();
+        new CommandLine(new App())
+                .setOut(new PrintWriter(sw))
+                .setColorScheme(Help.defaultColorScheme(Help.Ansi.OFF))
+                .setAbbreviatedSubcommandsAllowed(true)
+                .setSubcommandsCaseInsensitive(true)
+                .execute("help", "S");
+
+        String expected = String.format("" +
+                "Usage: <main class> sub%n" +
+                "This is a subcommand%n");
+        assertEquals(expected, sw.toString());
+    }
+
+    @Test
     public void testHelpSubcommandWithInvalidCommand() {
         @Command(mixinStandardHelpOptions = true, subcommands = {HelpTest.Sub.class, HelpCommand.class})
         class App implements Runnable{ public void run(){}}

--- a/src/test/java/picocli/HelpSubCommandTest.java
+++ b/src/test/java/picocli/HelpSubCommandTest.java
@@ -215,6 +215,7 @@ public class HelpSubCommandTest {
         assertEquals(String.format("Hi, colorScheme.ansi is OFF%n"), systemOutRule.getLog());
         assertEquals(String.format("Hello, colorScheme.ansi is OFF%n"), systemErrRule.getLog());
     }
+
     @Test
     public void testHelpSubcommandWithValidCommand() {
         @Command(subcommands = {HelpTest.Sub.class, HelpCommand.class})
@@ -225,6 +226,24 @@ public class HelpSubCommandTest {
                 .setOut(new PrintWriter(sw))
                 .setColorScheme(Help.defaultColorScheme(Help.Ansi.OFF))
                 .execute("help", "sub");
+
+        String expected = String.format("" +
+                "Usage: <main class> sub%n" +
+                "This is a subcommand%n");
+        assertEquals(expected, sw.toString());
+    }
+
+    @Test
+    public void testHelpSubcommandWithCaseInsensitiveValidCommand() {
+        @Command(subcommands = {HelpTest.Sub.class, HelpCommand.class})
+        class App implements Runnable{ public void run(){}}
+
+        StringWriter sw = new StringWriter();
+        new CommandLine(new App())
+                .setOut(new PrintWriter(sw))
+                .setColorScheme(Help.defaultColorScheme(Help.Ansi.OFF))
+                .setSubcommandsCaseInsensitive(true)
+                .execute("help", "SUB");
 
         String expected = String.format("" +
                 "Usage: <main class> sub%n" +
@@ -245,6 +264,28 @@ public class HelpSubCommandTest {
 
         String expected = String.format("" +
                 "Unknown subcommand 'abcd'.%n" +
+                "Usage: <main class> [-hV] [COMMAND]%n" +
+                "  -h, --help      Show this help message and exit.%n" +
+                "  -V, --version   Print version information and exit.%n" +
+                "Commands:%n" +
+                "  sub   This is a subcommand%n" +
+                "  help  Displays help information about the specified command%n");
+        assertEquals(expected, sw.toString());
+    }
+
+    @Test
+    public void testHelpSubcommandWithCaseSensitiveInvalidCommand() {
+        @Command(mixinStandardHelpOptions = true, subcommands = {HelpTest.Sub.class, HelpCommand.class})
+        class App implements Runnable{ public void run(){}}
+
+        StringWriter sw = new StringWriter();
+        new CommandLine(new App())
+                .setErr(new PrintWriter(sw))
+                .setColorScheme(Help.defaultColorScheme(Help.Ansi.OFF))
+                .execute("help", "SUB");
+
+        String expected = String.format("" +
+                "Unknown subcommand 'SUB'.%n" +
                 "Usage: <main class> [-hV] [COMMAND]%n" +
                 "  -h, --help      Show this help message and exit.%n" +
                 "  -V, --version   Print version information and exit.%n" +
@@ -392,7 +433,7 @@ public class HelpSubCommandTest {
     }
 
     @Test
-    public void testUsage_NoHeaderIfAllSubcommandHidden() {
+    public void testUsageNoHeaderIfAllSubcommandHidden() {
         @Command(name = "foo", description = "This is a foo sub-command", hidden = true) class Foo { }
         @Command(name = "bar", description = "This is a foo sub-command", hidden = true) class Bar { }
         @Command(name = "app", abbreviateSynopsis = true) class App { }
@@ -410,7 +451,7 @@ public class HelpSubCommandTest {
     }
 
     @Test
-    public void testHelp_allSubcommands() {
+    public void testHelpAllSubcommands() {
         @Command(name = "foo", description = "This is a visible subcommand") class Foo { }
         @Command(name = "bar", description = "This is a hidden subcommand", hidden = true) class Bar { }
         @Command(name = "app", subcommands = {Foo.class, Bar.class}) class App { }


### PR DESCRIPTION
This pull request will fix #1156.