### PR TITLE
Use .invalid domain name for InetAddress test

### DIFF
--- a/src/test/java/picocli/TypeConversionTest.java
+++ b/src/test/java/picocli/TypeConversionTest.java
@@ -514,7 +514,7 @@ public class TypeConversionTest {
     }
     @Test
     public void testInetAddressConvertersInvalidError() {
-        parseInvalidValue("-InetAddress", "%$::a?*!a", "java.net.UnknownHostException: ");
+        parseInvalidValue("-InetAddress", "test.invalid", "java.net.UnknownHostException: ");
     }
     @Test
     public void testUUIDConvertersInvalidError() {


### PR DESCRIPTION
Some DNS setups such as ISP "DNS hijacking" will return an IP address for garbage names. Using the ".invalid" domain specified in RFC 6761 makes the test more reliable.