### PR TITLE
Update to latest Asciidoctor gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.asciidoctor:asciidoctor-gradle-plugin:$asciidoctorGradlePluginVersion"
+        classpath "org.asciidoctor:asciidoctor-gradle-jvm:$asciidoctorGradlePluginVersion"
         classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-beta.8'
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:$gradleBintrayPluginVersion"
         classpath "gradle.plugin.org.beryx:badass-jar:1.1.3"
@@ -27,7 +27,7 @@ buildscript {
     }
 }
 
-apply plugin: 'org.asciidoctor.convert' // version '1.5.8.1'
+apply plugin: 'org.asciidoctor.jvm.convert' // version '3.2.0'
 apply plugin: 'distribution'
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
@@ -60,6 +60,15 @@ pluginManager.withPlugin('biz.aQute.bnd.builder') { // if plugin applied, execut
         from sourceSets.bundle.output
         bndfile = 'bnd.bnd'
         sourceSet = sourceSets.bundle
+    }
+}
+
+pluginManager.withPlugin('org.asciidoctor.jvm.convert') { // if plugin applied, execute this action
+    configurations {
+        tabbedCodeExt
+    }
+    dependencies {
+        tabbedCodeExt "com.bmuschko:asciidoctorj-tabbed-code-extension:0.3"
     }
 }
 
@@ -248,6 +257,7 @@ asciidoctor {
     sourceDir = file('docs')
     outputDir = file('build/docs')
     logDocuments = true
+    configurations 'tabbedCodeExt'
 //    backends 'pdf', 'html'
 //    attributes 'sourcedir': file('docs') //project.sourceSets.main.java.srcDirs[0]
 ////    attributes 'pdf-stylesdir': 'theme',

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-asciidoctorGradlePluginVersion = 1.6.1
+asciidoctorGradlePluginVersion = 3.2.0
 compileTestingVersion          = 0.18
 gradleBintrayPluginVersion     = 1.+
 groovyVersion       = 2.4.10

--- a/picocli-codegen/build.gradle
+++ b/picocli-codegen/build.gradle
@@ -126,12 +126,14 @@ task generateManpageAsciiDoc(type: JavaExec) {
     }
 }
 
-apply plugin: 'org.asciidoctor.convert'
+apply plugin: 'org.asciidoctor.jvm.convert'
 asciidoctor {
     dependsOn(generateManpageAsciiDoc)
     sourceDir = file("${project.buildDir}/picocli-generated-docs")
     outputDir = file("${project.buildDir}/docs")
     logDocuments = true
-    backends 'manpage', 'html5'
+    outputOptions {
+        backends = ['manpage', 'html5']
+    }
 }
 javadoc.dependsOn('asciidoctor')

--- a/picocli-examples/build.gradle
+++ b/picocli-examples/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.10"
     }
 }
 
@@ -25,7 +25,7 @@ dependencies {
     compile rootProject
     compile project(':picocli-groovy')
     implementation "org.jetbrains.kotlin:kotlin-stdlib"
-    implementation 'org.scala-lang:scala-library:2.13.2'
+    implementation 'org.scala-lang:scala-library:2.13.3'
     ivy     "org.apache.ivy:ivy:$ivyVersion" // for Intelli/J
     compile "org.codehaus.groovy:groovy-all:$groovyVersion",
             "org.apache.ivy:ivy:$ivyVersion", // for Intelli/J
@@ -38,7 +38,7 @@ dependencies {
             "org.hibernate.validator:hibernate-validator-annotation-processor:6.1.2.Final",
             "javax.el:javax.el-api:3.0.0",
             "org.glassfish.web:javax.el:2.2.6"
-    implementation "org.jetbrains.kotlin:kotlin-script-runtime:1.3.72"
+    implementation "org.jetbrains.kotlin:kotlin-script-runtime:1.4.10"
 }
 tasks.withType(GroovyCompile) {
     // this, and the `configurations {ivy}` section, are a workaround for the dreaded


### PR DESCRIPTION
This PR updates gradle Asciidoctor plugin to latest version.
After applying this PR, `gradle ascii` works again on master.

Unfortunately, now tabbed panes do not show up any more. :-(
Seems like the used extension is not picked up any more by the new version. I will look into that soon.
For now, the produced `index.html` is **not** ready for being published to the web site.