### PR TITLE
Add source code highlighting for Kotlin, Scala and Groovy

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -7,7 +7,8 @@
 :numbered:
 :toclevels: 2
 :toc-title: Features
-:source-highlighter: coderay
+:source-highlighter: rouge
+:rouge-languages: kotlin, groovy, scala
 //:source-highlighter: highlightjs
 //:highlightjs-theme: darkula
 :icons: font


### PR DESCRIPTION
This PR changes changes source highlighter to `rouge` since the current highlighter `coderay` does not support Kotlin and Scala.
This gives a better result for the listings in chapter 30 `Picocli in Other Languages`.