### PR TITLE
Fix: Show copy buttons in code blocks (#1198)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -258,6 +258,7 @@ asciidoctor {
     outputDir = file('build/docs')
     logDocuments = true
     configurations 'tabbedCodeExt'
+    baseDirFollowsSourceDir()
 //    backends 'pdf', 'html'
 //    attributes 'sourcedir': file('docs') //project.sourceSets.main.java.srcDirs[0]
 ////    attributes 'pdf-stylesdir': 'theme',


### PR DESCRIPTION
After updating to latest asciidoctor gradle plugin (#1202), copy buttons in code blocks were [not displayed any more](https://github.com/remkop/picocli/pull/1202#issuecomment-703971199).
This is corrected with this PR.