### PR TITLE
Add Maven coordinates to JLine2/3 modules

### DIFF
--- a/picocli-shell-jline2/README.md
+++ b/picocli-shell-jline2/README.md
@@ -33,6 +33,16 @@ get command line TAB auto-completion for a picocli-based application running in 
 
 ## Example
 
+### Maven 
+
+```xml
+<dependency>
+    <groupId>info.picocli</groupId>
+    <artifactId>picocli-shell-jline2</artifactId>
+    <version>4.5.1</version>
+</dependency>
+```
+
 ```java
 import java.io.IOException;
 import java.io.PrintWriter;

--- a/picocli-shell-jline3/README.md
+++ b/picocli-shell-jline3/README.md
@@ -67,6 +67,16 @@ JLine [Wiki](https://github.com/jline/jline3/wiki) and some more [Demos](https:/
 
 ## Example
 
+### Maven 
+
+```xml
+<dependency>
+    <groupId>info.picocli</groupId>
+    <artifactId>picocli-shell-jline3</artifactId>
+    <version>4.5.1</version>
+</dependency>
+```
+
 ### Older versions
 
 See examples for older versions on the [wiki](https://github.com/remkop/picocli/wiki/JLine-3-Examples).


### PR DESCRIPTION
Minor documentation improvement. 

*Story behind it*
I wanted to try out the JLine integration. I copy pasted the example and then simply started to add imports. However, my IDE couldn't find the imports, so I was obviously missing some dependency. But the dependency to be used for this integration is not mentioned anywhere in the docs.

