### PR TITLE
Update patterns that our compiler will complain about.

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -10111,7 +10111,7 @@ public class CommandLine {
             public Method getDeclaringExecutable() { return method; }
             @Override public <T extends Annotation> T getAnnotation(Class<T> annotationClass) {
                 for (Annotation annotation : getDeclaredAnnotations()) {
-                    if (annotationClass.isAssignableFrom(annotation.getClass())) { return annotationClass.cast(annotation); }
+                    if (annotationClass.isAssignableFrom(annotation.annotationType())) { return annotationClass.cast(annotation); }
                 }
                 return null;
             }
@@ -17626,7 +17626,7 @@ public class CommandLine {
             for (int i = matchCount, lastMatchChunk = matchCount; i < abbreviatedKeyChunks.size(); i++, matchCount++) {
                 boolean found = false;
                 for (int j = lastMatchChunk; j < keyChunks.size(); j++) {
-                    if (found = startsWith(keyChunks.get(j), abbreviatedKeyChunks.get(i), caseInsensitive)) {
+                    if ((found = startsWith(keyChunks.get(j), abbreviatedKeyChunks.get(i), caseInsensitive))) {
                         lastMatchChunk = j + 1;
                         break;
                     }


### PR DESCRIPTION
Calling getClass() is likely to return an internal Proxy class (ie
com.sun.proxy.$Proxy1) so use annotationType() instead.

Assignment in an if statement is ambiguous so wrap in parens to make it
obvious that it's intended.

This are things that our compiler will fail on.