### PR TITLE
Bump Spring-Boot-Starter to latest version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ jlineVersion        = 2.14.6
 jline3Version       = 3.16.0
 junitDepVersion     = 4.11
 junitVersion        = 4.12
-springBootVersion   = 2.2.2.RELEASE
+springBootVersion   = 2.3.5.RELEASE
 
 # projectPreviousReleaseVersion is non-SNAPSHOT, only published releases
 projectPreviousReleaseVersion = 4\\.5\\.2


### PR DESCRIPTION
picocli-spring-boot-starter module has a dependency on spring-boot-starter 2.2.2.RELEASE, which is outdated.
Starting a project with this outdated module using Java 15 results in: `Unsupported class file major version 59`.
This PR fixes this by bumping spring-boot starter to latest version 2.3.5.RELEASE.