### PR TITLE
Quick guide: add Kotlin + Scala versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ See the [source code](https://github.com/remkop/picocli/blob/master/src/main/jav
 
 ### Gradle
 ```
-compile 'info.picocli:picocli:4.5.2'
+implementation 'info.picocli:picocli:4.5.2'
 ```
 ### Maven
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -288,6 +288,10 @@ task bumpReadmeVersion {
                 include(name: '**/pom.xml')
                 include(name: '**/build.gradle')
             }
+            fileset(dir: './picocli-examples/generate-man-pages/') {
+                include(name: '**/pom.xml')
+                include(name: '**/build.gradle')
+            }
             //fileset(dir: './picocli-examples/src/main/groovy/', includes: '**/*.groovy')
         }
     }

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -6851,7 +6851,26 @@ This is the recommended way when you want to use the picocli <<Annotation Proces
     GitRebase.class,
     GitTag.class
 })
-public class Git { ... }
+public class Git { /* ... */ }
+----
+
+.Groovy
+[source,groovy,role="secondary"]
+----
+@Command(subcommands = [
+    GitStatus.class,
+    GitCommit.class,
+    GitAdd.class,
+    GitBranch.class,
+    GitCheckout.class,
+    GitClone.class,
+    GitDiff.class,
+    GitMerge.class,
+    GitPush.class,
+    GitRebase.class,
+    GitTag.class
+])
+public class Git { /* ... */ }
 ----
 
 .Kotlin
@@ -6870,7 +6889,7 @@ public class Git { ... }
     GitRebase::class,
     GitTag::class]
 )
-public class Git { ... }
+public class Git { /* ... */ }
 ----
 
 Subcommands referenced in a `subcommands` attribute _must_ have a `@Command` annotation with a `name` attribute, or an exception is thrown from the `CommandLine` constructor.
@@ -6901,6 +6920,23 @@ The specified name is used by the parser to recognize subcommands in the command
 [source,java,role="primary"]
 ----
 CommandLine commandLine = new CommandLine(new Git())
+        .addSubcommand("status",   new GitStatus())
+        .addSubcommand("commit",   new GitCommit())
+        .addSubcommand("add",      new GitAdd())
+        .addSubcommand("branch",   new GitBranch())
+        .addSubcommand("checkout", new GitCheckout())
+        .addSubcommand("clone",    new GitClone())
+        .addSubcommand("diff",     new GitDiff())
+        .addSubcommand("merge",    new GitMerge())
+        .addSubcommand("push",     new GitPush())
+        .addSubcommand("rebase",   new GitRebase())
+        .addSubcommand("tag",      new GitTag());
+----
+
+.Groovy
+[source,groovy,role="secondary"]
+----
+def commandLine = new CommandLine(new Git())
         .addSubcommand("status",   new GitStatus())
         .addSubcommand("commit",   new GitCommit())
         .addSubcommand("add",      new GitAdd())
@@ -6982,6 +7018,42 @@ class Bar implements Callable<Integer> {
     int baz(@Option(names = "-z") int z) {
         System.out.printf("hi from baz, z=%d%n", z);
         return 45;
+    }
+}
+----
+
+.Groovy
+[source,groovy,role="secondary"]
+----
+@Command(name = "foo", subcommands = Bar.class)
+class Foo implements Callable<Integer> {
+    @Option(names = "-x") def x
+
+    @Override public Integer call() {
+        println "hi from foo, x=$x"
+        def ok = true;
+        return ok ? 0 : 1 // exit code
+    }
+
+    public static void main(String... args) {
+        def exitCode = new CommandLine(new Foo()).execute(args)
+        System.exit(exitCode)
+    }
+}
+
+@Command(name = "bar", description = "I'm a subcommand of `foo`")
+class Bar implements Callable<Integer> {
+    @Option(names = "-y") int y
+
+    @Override public Integer call() {
+        println "hi from bar, y=$y"
+        return 23
+    }
+
+    @Command(name = "baz", description = "I'm a subcommand of `bar`")
+    int baz(@Option(names = "-z") int z) {
+        println "hi from baz, z=$z"
+        return 45
     }
 }
 ----
@@ -7101,6 +7173,35 @@ class MyApp implements Runnable {
 }
 ----
 
+.Groovy
+[source,groovy,role="secondary"]
+----
+@Command(subcommands = [Sub1.class, Sub2.class, Sub3.class])
+class MyApp implements Runnable {
+
+    // A reference to this method can be used as a custom execution strategy
+    // that first calls the init() method,
+    // and then delegates to the default execution strategy.
+    def int executionStrategy(ParseResult parseResult) {
+        init(); // custom initialization to be done before executing any command or subcommand
+        return new CommandLine.RunLast().execute(parseResult); // default execution strategy
+    }
+
+    def void init() {
+        // ...
+    }
+
+    public static void main(String[] args) {
+        def app = new MyApp();
+        new CommandLine(app)
+                .setExecutionStrategy(app.&executionStrategy)
+                .execute(args);
+    }
+
+    // ...
+}
+----
+
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
@@ -7156,6 +7257,18 @@ class FileUtils {
     @Option(names = {"-d", "--directory"},
             description = "this option applies to all subcommands")
     File baseDirectory;
+}
+----
+
+.Groovy
+[source,groovy,role="secondary"]
+----
+@Command(name = "fileutils", subcommands = [ListFiles.class])
+class FileUtils {
+
+    @Option(names = ["-d", "--directory"],
+            description = "this option applies to all subcommands")
+    def baseDirectory;
 }
 ----
 

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -336,7 +336,7 @@ See the https://github.com/remkop/picocli/tree/master/picocli-codegen[`picocli-c
 ===== Gradle
 ```
 dependencies {
-    compile 'info.picocli:picocli:4.5.3-SNAPSHOT'
+    implementation 'info.picocli:picocli:4.5.3-SNAPSHOT'
     annotationProcessor 'info.picocli:picocli-codegen:4.5.3-SNAPSHOT'
 }
 ```
@@ -11570,7 +11570,7 @@ See the <<Source,source code>> below. Copy and paste it into a file called `Comm
 
 === Gradle
 ----
-compile 'info.picocli:picocli:4.5.3-SNAPSHOT'
+implementation 'info.picocli:picocli:4.5.3-SNAPSHOT'
 ----
 
 === Maven

--- a/docs/quick-guide.adoc
+++ b/docs/quick-guide.adoc
@@ -7,7 +7,8 @@
 :numbered:
 :toclevels: 1 // show little detail in the TOC, to make this document less intimidating
 :toc-title: Features
-:source-highlighter: coderay
+:source-highlighter: rouge
+:rouge-languages: kotlin, groovy, scala
 :icons: font
 :imagesdir: images
 :linkattrs:
@@ -196,8 +197,8 @@ ISOCodeResolver country cn fr th ro no
 
 === ISOCodeResolver source code explained
 
-.ISOCodeResolver source code
-[source,java]
+.Java
+[source,java,role="primary"]
 ----
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -225,8 +226,8 @@ public class ISOCodeResolver { // <1>
     }
 
     public static void main(String[] args) {
-        int exitCode = new CommandLine(new ISOCodeResolver()).execute(args);  // <5>
-        System.exit(exitCode);  // <6>
+        int exitCode = new CommandLine(new ISOCodeResolver()).execute(args); // <5>
+        System.exit(exitCode); // <6>
     }
 }
 
@@ -244,6 +245,91 @@ class SubcommandAsClass implements Runnable {
                     code.toLowerCase(), new Locale(code).getDisplayLanguage());
         }
     }
+}
+----
+
+.Kotlin
+[source,kotlin,role="secondary"]
+----
+import picocli.CommandLine
+import picocli.CommandLine.Model.CommandSpec
+import picocli.CommandLine.*
+import java.util.Locale
+import kotlin.system.exitProcess
+
+@Command(
+    name = "ISOCodeResolver",
+    subcommands = [SubcommandAsClass::class, HelpCommand::class], // <2>
+    description = ["Resolves ISO country codes (ISO-3166-1) or language codes (ISO 639-1/-2)"])
+class ISOCodeResolver { // <1>
+    @Spec lateinit var spec: CommandSpec
+
+    @Command(name = "country", description = ["Resolves ISO country codes (ISO-3166-1)"]) // <3>
+    fun subCommandViaMethod(@Parameters(arity = "1..*", paramLabel = "<countryCode>",
+            description = ["country code(s) to be resolved"]) countryCodes: Array<String>) {
+        for (code in countryCodes) {
+            println("${code.toUpperCase()}: ${Locale("", code).displayCountry}")
+        }
+    }
+}
+
+fun main(args: Array<String>) {
+    val exitCode = CommandLine(ISOCodeResolver()).execute(*args) // <5>
+    exitProcess(exitCode) // <6>
+}
+
+@Command(name = "language", description = ["Resolves ISO language codes (ISO-639-1/-2)"]) // <4>
+class SubcommandAsClass : Runnable {
+    @Parameters(arity = "1..*", paramLabel = "<languageCode>", description = ["language code(s)"])
+    private lateinit var languageCodes: Array<String>
+
+    override fun run() {
+        for (code in languageCodes) {
+            System.out.println("${code.toLowerCase()}: ${Locale(code).displayLanguage}")
+        }
+    }
+}
+----
+
+.Scala
+[source,scala,role="secondary"]
+----
+import picocli.CommandLine
+import picocli.CommandLine.{Command, HelpCommand, Parameters}
+import picocli.CommandLine.Model.CommandSpec
+import java.util.Locale
+
+@Command(name = "ISOCodeResolver", subcommands = Array(classOf[SubcommandAsClass], classOf[HelpCommand]), // <2>
+  description = Array("Resolves ISO country codes (ISO-3166-1) or language codes (ISO 639-1/-2)"))
+class ISOCodeResolver { // <1>
+  val spec: CommandSpec = null
+
+  @Command(name = "country", description = Array("Resolves ISO country codes (ISO-3166-1)")) // <3>
+  def subCommandViaMethod(@Parameters(arity = "1..*", paramLabel = "<countryCode>",
+    description = Array("country code(s) to be resolved")) countryCodes: Array[String]): Unit = {
+    for (code <- countryCodes) {
+      println(s"${code.toUpperCase()}: ".concat(new Locale("", code).getDisplayCountry))
+    }
+  }
+}
+
+@Command(name = "language", description = Array("Resolves language codes (ISO-639-1/-2)")) // <4>
+class SubcommandAsClass extends Runnable {
+  @Parameters(arity = "1..*", paramLabel = "<languageCode>", description = Array("language code(s)"))
+  private val languageCodes = new Array[String](0)
+
+  override def run(): Unit = {
+    for (code <- languageCodes) {
+      println(s"${code.toUpperCase()}: ".concat(new Locale(code).getDisplayLanguage))
+    }
+  }
+}
+
+object ISOCodeResolver {
+  def main(args: Array[String]): Unit = {
+    val exitCode = new CommandLine(new ISOCodeResolver).execute(args: _*) // <5>
+    System.exit(exitCode) // <6>
+  }
 }
 ----
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -6,4 +6,5 @@ zipStorePath=wrapper/dists
 #distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 #distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
 #distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-all.zip
+#distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip

--- a/picocli-codegen/README.adoc
+++ b/picocli-codegen/README.adoc
@@ -108,7 +108,7 @@ See <<Picocli Processor Options,processor options>> below.
 Use the `annotationProcessor` path in Gradle https://docs.gradle.org/4.6/release-notes.html#convenient-declaration-of-annotation-processor-dependencies[4.6 and higher]:
 ```groovy
 dependencies {
-    compile 'info.picocli:picocli:4.5.2'
+    implementation 'info.picocli:picocli:4.5.2'
     annotationProcessor 'info.picocli:picocli-codegen:4.5.2'
 }
 ```
@@ -116,7 +116,7 @@ dependencies {
 For Gradle versions prior to 4.6, use `compileOnly`, to prevent the `picocli-codegen` jar from being a transitive dependency included in the artifact the module produces.
 ```groovy
 dependencies {
-    compile 'info.picocli:picocli:4.5.2'
+    implementation 'info.picocli:picocli:4.5.2'
     compileOnly 'info.picocli:picocli-codegen:4.5.2'
 }
 ```
@@ -328,7 +328,7 @@ Note that the `picocli-codegen` module is only added as a dependency for the `ex
     <plugin>
       <groupId>org.codehaus.mojo</groupId>
       <artifactId>exec-maven-plugin</artifactId>
-      <version>1.6.0</version>
+      <version>3.0.0</version>
       <executions>
         <execution>
           <id>generateGraalReflectionConfig</id>
@@ -373,7 +373,7 @@ configurations {
     generateConfig
 }
 dependencies {
-    compile 'info.picocli:picocli:4.5.2'
+    implementation 'info.picocli:picocli:4.5.2'
     generateConfig 'info.picocli:picocli-codegen:4.5.2'
 }
 ----
@@ -439,7 +439,7 @@ Note that the `picocli-codegen` module is only added as a dependency for the `ex
     <plugin>
       <groupId>org.codehaus.mojo</groupId>
       <artifactId>exec-maven-plugin</artifactId>
-      <version>1.6.0</version>
+      <version>3.0.0</version>
       <executions>
         <execution>
           <id>generateGraalResourceConfig</id>
@@ -483,7 +483,7 @@ configurations {
     generateConfig
 }
 dependencies {
-    compile 'info.picocli:picocli:4.5.2'
+    implementation 'info.picocli:picocli:4.5.2'
     generateConfig 'info.picocli:picocli-codegen:4.5.2'
 }
 ----
@@ -546,7 +546,7 @@ Note that the `picocli-codegen` module is only added as a dependency for the `ex
     <plugin>
       <groupId>org.codehaus.mojo</groupId>
       <artifactId>exec-maven-plugin</artifactId>
-      <version>1.6.0</version>
+      <version>3.0.0</version>
       <executions>
         <execution>
           <id>generateGraalDynamicProxyConfig</id>
@@ -590,7 +590,7 @@ configurations {
     generateConfig
 }
 dependencies {
-    compile 'info.picocli:picocli:4.5.2'
+    implementation 'info.picocli:picocli:4.5.2'
     generateConfig 'info.picocli:picocli-codegen:4.5.2'
 }
 ----
@@ -625,7 +625,7 @@ You will also need the https://asciidoctor.org/docs/asciidoctor-gradle-plugin/[A
 [source,groovy]
 ----
 dependencies {
-    compile "info.picocli:picocli:4.5.2"
+    implementation "info.picocli:picocli:4.5.2"
     annotationProcessor "info.picocli:picocli-codegen:4.5.2"
 }
 
@@ -640,13 +640,15 @@ task generateManpageAsciiDoc(type: JavaExec) {
     args mainClassName, "--outdir=${project.buildDir}/generated-picocli-docs", "-v" //, "--template-dir=src/docs/mantemplates"
 }
 
-apply plugin: 'org.asciidoctor.convert'
+apply plugin: 'org.asciidoctor.jvm.convert'
 asciidoctor {
     dependsOn(generateManpageAsciiDoc)
     sourceDir = file("${project.buildDir}/generated-picocli-docs")
     outputDir = file("${project.buildDir}/docs")
     logDocuments = true
-    backends 'manpage', 'html5'
+    outputOptions {
+        backends = ['manpage', 'html5']
+    }
 }
 ----
 
@@ -674,7 +676,7 @@ Note that the `picocli-codegen` module is only added as a dependency for the `ex
     <plugin>
       <groupId>org.codehaus.mojo</groupId>
       <artifactId>exec-maven-plugin</artifactId>
-      <version>1.6.0</version>
+      <version>3.0.0</version>
       <executions>
         <execution>
           <id>generateManPages</id>
@@ -707,7 +709,7 @@ Note that the `picocli-codegen` module is only added as a dependency for the `ex
     <plugin>
       <groupId>org.asciidoctor</groupId>
       <artifactId>asciidoctor-maven-plugin</artifactId>
-      <version>1.6.0</version>
+      <version>2.1.0</version>
       <executions>
         <execution>
           <id>output-html</id>

--- a/picocli-codegen/build.gradle
+++ b/picocli-codegen/build.gradle
@@ -110,7 +110,7 @@ task generateManpageAsciiDoc(type: JavaExec) {
     dependsOn(classes)
     group = "Documentation"
     description = "Generate AsciiDoc manpage"
-    classpath(configurations.compile, configurations.annotationProcessor, sourceSets.main.runtimeClasspath)
+    classpath(configurations.compileClasspath, configurations.annotationProcessor, sourceSets.main.runtimeClasspath)
     main 'picocli.codegen.docgen.manpage.ManPageGenerator'
     args 'picocli.codegen.docgen.manpage.ManPageGenerator$App',
             'picocli.codegen.aot.graalvm.DynamicProxyConfigGenerator$App',

--- a/picocli-examples/annotation-processing/example-gradle-project-kotlin-graal-nativeimage/build.gradle
+++ b/picocli-examples/annotation-processing/example-gradle-project-kotlin-graal-nativeimage/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm' version '1.3.72'
+    id 'org.jetbrains.kotlin.jvm' version '1.4.10'
     id 'application'
-    id "com.palantir.graal" version "0.7.1-12-g028cd78"
+    id "com.palantir.graal" version "0.7.1-20-g113a84d"
 }
 
 def mainCommandClass = "picocli.examples.kotlin.Checksum"
@@ -13,7 +13,7 @@ version '1.0-SNAPSHOT'
 sourceCompatibility = 8
 
 application{
-    mainClassName = mainCommandClass
+    mainClass.set(mainCommandClass)
 }
 
 
@@ -49,10 +49,10 @@ task uberJar(type: Jar) {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-    testCompile 'org.jetbrains.kotlin:kotlin-test-junit5:1.3.72'
+    testImplementation  'org.jetbrains.kotlin:kotlin-test-junit5:1.4.10'
 
-    testImplementation "org.junit.jupiter:junit-jupiter:5.4.2"
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")
+    testImplementation "org.junit.jupiter:junit-jupiter:5.7.0"
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.0")
 }
 
 
@@ -76,7 +76,7 @@ configurations {
     generateConfig
 }
 dependencies {
-    compile 'info.picocli:picocli:4.5.2'
+    implementation 'info.picocli:picocli:4.5.2'
     generateConfig 'info.picocli:picocli-codegen:4.5.2'
 }
 

--- a/picocli-examples/annotation-processing/example-gradle-project/build.gradle
+++ b/picocli-examples/annotation-processing/example-gradle-project/build.gradle
@@ -14,10 +14,10 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testImplementation group: 'junit', name: 'junit', version: '4.13.1'
 }
 dependencies {
-    compile 'info.picocli:picocli:4.5.2'
+    implementation 'info.picocli:picocli:4.5.2'
     annotationProcessor 'info.picocli:picocli-codegen:4.5.2'
     //compileOnly 'info.picocli:picocli-codegen:4.5.2' // in pre-Gradle 4.6
 }

--- a/picocli-examples/generate-man-pages/example-gradle-project/build.gradle
+++ b/picocli-examples/generate-man-pages/example-gradle-project/build.gradle
@@ -8,14 +8,14 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.asciidoctor:asciidoctor-gradle-plugin:1.6.1"
+        classpath "org.asciidoctor:asciidoctor-gradle-jvm:3.2.0"
     }
 }
 
 plugins {
     id 'java'
 }
-apply plugin: 'org.asciidoctor.convert'
+apply plugin: 'org.asciidoctor.jvm.convert'
 
 
 group 'org.mycompany.myproject'
@@ -30,11 +30,11 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testImplementation group: 'junit', name: 'junit', version: '4.13.1'
 }
 dependencies {
-    compile "info.picocli:picocli:4.2.0"
-    annotationProcessor "info.picocli:picocli-codegen:4.2.0"
+    implementation "info.picocli:picocli:4.5.2"
+    annotationProcessor "info.picocli:picocli-codegen:4.5.2"
 }
 
 project.ext {
@@ -45,18 +45,20 @@ task generateManpageAsciiDoc(type: JavaExec) {
     dependsOn(classes)
     group = "Documentation"
     description = "Generate AsciiDoc manpage"
-    classpath(configurations.compile, configurations.annotationProcessor, sourceSets.main.runtimeClasspath)
+    classpath(configurations.compileClasspath, configurations.annotationProcessor, sourceSets.main.runtimeClasspath)
     main 'picocli.codegen.docgen.manpage.ManPageGenerator'
     args project.ext.mainClassName, "--outdir=${project.buildDir}/generated-picocli-docs", "-v", "--template-dir=src/docs/mantemplates"
 }
 
-apply plugin: 'org.asciidoctor.convert'
+apply plugin: 'org.asciidoctor.jvm.convert'
 asciidoctor {
     dependsOn(generateManpageAsciiDoc)
     sourceDir = file("${project.buildDir}/generated-picocli-docs")
     outputDir = file("${project.buildDir}/docs")
     logDocuments = true
-    backends 'manpage', 'html5'
+    outputOptions {
+        backends = ['manpage', 'html5']
+    }
 }
 assemble.dependsOn(asciidoctor)
 

--- a/picocli-examples/generate-man-pages/example-maven-project/pom.xml
+++ b/picocli-examples/generate-man-pages/example-maven-project/pom.xml
@@ -14,7 +14,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
+        <version>3.8.1</version>
         <configuration>
           <source>1.6</source>
           <target>1.6</target>
@@ -27,20 +27,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.2</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-            <id>jar</id>
-          </execution>
-        </executions>
+        <version>3.2.0</version>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>1.6.0</version>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <id>generateManPages</id>
@@ -67,7 +59,7 @@
           <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli-codegen</artifactId>
-            <version>4.2.0</version>
+            <version>4.5.2</version>
             <type>jar</type>
           </dependency>
         </dependencies>
@@ -75,7 +67,7 @@
       <plugin>
         <groupId>org.asciidoctor</groupId>
         <artifactId>asciidoctor-maven-plugin</artifactId>
-        <version>1.6.0</version>
+        <version>2.1.0</version>
         <executions>
           <execution>
             <id>output-html</id>
@@ -125,12 +117,12 @@
     <dependency>
       <groupId>info.picocli</groupId>
       <artifactId>picocli</artifactId>
-      <version>4.2.0</version>
+      <version>4.5.2</version>
     </dependency>
     <dependency>
       <groupId>info.picocli</groupId>
       <artifactId>picocli-codegen</artifactId>
-      <version>4.2.0</version>
+      <version>4.5.2</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/picocli-spring-boot-starter/README.md
+++ b/picocli-spring-boot-starter/README.md
@@ -27,7 +27,7 @@ Maven:
 Gradle:
 ```
 dependencies {
-    compile "info.picocli:picocli-spring-boot-starter:4.5.2"
+    implementation "info.picocli:picocli-spring-boot-starter:4.5.2"
 }
 ```
 


### PR DESCRIPTION
This PR adds Kotlin + Scala versions to the subcommands example of the quick guide.
It adds Groovy versions to sample code in chapter 17 'Subcommands' of the quick guide.

It contains some minor fixes to the gradle build scripts of the example projects:
- avoid deprecation warnings
- bump to latest version of the dependencies, like ascii-doctor-plugin, ... 

It also fixes deprecated syntax in gradle build scripts in a few README files.