### PR TITLE
Allow users of picocli-shell-jline3 to use `clear` command and a nicer `help` command

### DIFF
--- a/picocli-shell-jline3/src/main/java/picocli/shell/jline3/PicocliCommands.java
+++ b/picocli-shell-jline3/src/main/java/picocli/shell/jline3/PicocliCommands.java
@@ -22,6 +22,8 @@ import org.jline.reader.Completer;
 import org.jline.reader.LineReader;
 import org.jline.reader.ParsedLine;
 import org.jline.reader.impl.LineReaderImpl;
+import org.jline.reader.impl.completer.ArgumentCompleter;
+import org.jline.reader.impl.completer.NullCompleter;
 import org.jline.reader.impl.completer.SystemCompleter;
 import org.jline.utils.AttributedString;
 
@@ -110,9 +112,9 @@ public class PicocliCommands implements CommandRegistry {
         return out;
     }
 
-    private class PicocliCompleter implements Completer {
+    private class PicocliCompleter extends ArgumentCompleter implements Completer {
 
-        public PicocliCompleter() {}
+        public PicocliCompleter() { super(NullCompleter.INSTANCE); }
 
         @Override
         public void complete(LineReader reader, ParsedLine commandLine, List<Candidate> candidates) {

--- a/picocli-shell-jline3/src/main/java/picocli/shell/jline3/PicocliCommands.java
+++ b/picocli-shell-jline3/src/main/java/picocli/shell/jline3/PicocliCommands.java
@@ -1,7 +1,6 @@
 package picocli.shell.jline3;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -9,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.jline.builtins.Options.HelpException;
@@ -123,17 +121,11 @@ public class PicocliCommands implements CommandRegistry {
         }
     }
 
-    private final Supplier<Path> workDir;
     private final CommandLine cmd;
     private final Set<String> commands;
     private final Map<String,String> aliasCommand = new HashMap<>();
 
-    public PicocliCommands(Path workDir, CommandLine cmd) {
-        this(() -> workDir, cmd);
-    }
-
-    public PicocliCommands(Supplier<Path> workDir, CommandLine cmd) {
-        this.workDir = workDir;
+    public PicocliCommands(CommandLine cmd) {
         this.cmd = cmd;
         commands = cmd.getCommandSpec().subcommands().keySet();
         for (String c: commands) {

--- a/picocli-shell-jline3/src/main/java/picocli/shell/jline3/PicocliCommands.java
+++ b/picocli-shell-jline3/src/main/java/picocli/shell/jline3/PicocliCommands.java
@@ -50,13 +50,13 @@ public class PicocliCommands implements CommandRegistry {
             description = "Clears the screen", version = "1.0")
     static class ClearScreen implements Callable<Void> {
 
-    	private final LineReaderImpl reader;
+        private final LineReaderImpl reader;
 
         ClearScreen(LineReaderImpl reader) {
-			this.reader = reader;
-		}
+            this.reader = reader;
+        }
 
-		public Void call() throws IOException {
+        public Void call() throws IOException {
             reader.clearScreen();
             return null;
         }
@@ -83,14 +83,14 @@ public class PicocliCommands implements CommandRegistry {
     }
 
     public void includeClearScreenCommand(LineReader reader) {
-    	if (reader == null) return;
-    	ClearScreen clearScreen = new ClearScreen((LineReaderImpl) reader);
-    	cmd.addSubcommand(clearScreen);
+        if (reader == null) return;
+        ClearScreen clearScreen = new ClearScreen((LineReaderImpl) reader);
+        cmd.addSubcommand(clearScreen);
 
-    	commands.add("clear");
+        commands.add("clear");
 
-    	aliasCommand.put("clear", "clear");
-    	aliasCommand.put("cls", "clear");
+        aliasCommand.put("clear", "clear");
+        aliasCommand.put("cls", "clear");
     }
 
     /**

--- a/picocli-shell-jline3/src/test/java/picocli/shell/jline3/example/Example.java
+++ b/picocli-shell-jline3/src/test/java/picocli/shell/jline3/example/Example.java
@@ -143,6 +143,7 @@ public class Example {
             try (Terminal terminal = TerminalBuilder.builder().build()) {
                 SystemRegistry systemRegistry = new SystemRegistryImpl(parser, terminal, Example::workDir, null);
                 systemRegistry.setCommandRegistries(builtins, picocliCommands);
+                systemRegistry.register("help", picocliCommands);
 
                 LineReader reader = LineReaderBuilder.builder()
                         .terminal(terminal)

--- a/picocli-shell-jline3/src/test/java/picocli/shell/jline3/example/Example.java
+++ b/picocli-shell-jline3/src/test/java/picocli/shell/jline3/example/Example.java
@@ -137,12 +137,12 @@ public class Example {
             builtins.alias("bindkey", "keymap");
             // set up picocli commands
             CliCommands commands = new CliCommands();
-            
+
             PicocliCommandsFactory factory = new PicocliCommandsFactory();
             // Or, if you have your own factory, you can chain them like this:
             // MyCustomFactory customFactory = createCustomFactory(); // your application custom factory
-            // PicocliCommands.Factory factory = new PicocliCommands.Factory(customFactory); // chain the factories
-            
+            // PicocliCommandsFactory factory = new PicocliCommandsFactory(customFactory); // chain the factories
+
             CommandLine cmd = new CommandLine(commands, factory);
             PicocliCommands picocliCommands = new PicocliCommands(Example::workDir, cmd);
 
@@ -159,7 +159,7 @@ public class Example {
                         .variable(LineReader.LIST_MAX, 50)   // max tab completion candidates
                         .build();
                 builtins.setLineReader(reader);
-                factory.setLineReader(reader);
+                factory.setLineReader((LineReaderImpl) reader);
                 TailTipWidgets widgets = new TailTipWidgets(reader, systemRegistry::commandDescription, 5, TailTipWidgets.TipType.COMPLETER);
                 widgets.enable();
                 KeyMap<Binding> keyMap = reader.getKeyMaps().get("main");

--- a/picocli-shell-jline3/src/test/java/picocli/shell/jline3/example/Example.java
+++ b/picocli-shell-jline3/src/test/java/picocli/shell/jline3/example/Example.java
@@ -155,7 +155,7 @@ public class Example {
                         .variable(LineReader.LIST_MAX, 50)   // max tab completion candidates
                         .build();
                 builtins.setLineReader(reader);
-                factory.setLineReader((LineReaderImpl) reader);
+                factory.setTerminal(terminal);
                 TailTipWidgets widgets = new TailTipWidgets(reader, systemRegistry::commandDescription, 5, TailTipWidgets.TipType.COMPLETER);
                 widgets.enable();
                 KeyMap<Binding> keyMap = reader.getKeyMaps().get("main");

--- a/picocli-shell-jline3/src/test/java/picocli/shell/jline3/example/Example.java
+++ b/picocli-shell-jline3/src/test/java/picocli/shell/jline3/example/Example.java
@@ -42,17 +42,11 @@ public class Example {
                     ""},
             footer = {"", "Press Ctl-D to exit."},
             subcommands = {
-                    MyCommand.class, ClearScreen.class, CommandLine.HelpCommand.class})
+                    MyCommand.class, CommandLine.HelpCommand.class})
     static class CliCommands implements Runnable {
-        LineReaderImpl reader;
         PrintWriter out;
 
         CliCommands() {}
-
-        public void setReader(LineReader reader){
-            this.reader = (LineReaderImpl)reader;
-            out = reader.getTerminal().writer();
-        }
 
         public void run() {
             out.println(new CommandLine(this).getUsageMessage());
@@ -128,21 +122,6 @@ public class Example {
         }
     }
 
-    /**
-     * Command that clears the screen.
-     */
-    @Command(name = "cls", aliases = "clear", mixinStandardHelpOptions = true,
-            description = "Clears the screen", version = "1.0")
-    static class ClearScreen implements Callable<Void> {
-
-        @ParentCommand CliCommands parent;
-
-        public Void call() throws IOException {
-            parent.reader.clearScreen();
-            return null;
-        }
-    }
-
     private static Path workDir() {
         return Paths.get(System.getProperty("user.dir"));
     }
@@ -172,7 +151,7 @@ public class Example {
                         .variable(LineReader.LIST_MAX, 50)   // max tab completion candidates
                         .build();
                 builtins.setLineReader(reader);
-                commands.setReader(reader);
+                picocliCommands.includeClearScreenCommand(reader);
                 TailTipWidgets widgets = new TailTipWidgets(reader, systemRegistry::commandDescription, 5, TailTipWidgets.TipType.COMPLETER);
                 widgets.enable();
                 KeyMap<Binding> keyMap = reader.getKeyMaps().get("main");

--- a/picocli-shell-jline3/src/test/java/picocli/shell/jline3/example/Example.java
+++ b/picocli-shell-jline3/src/test/java/picocli/shell/jline3/example/Example.java
@@ -17,6 +17,7 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ParentCommand;
 import picocli.shell.jline3.PicocliCommands;
+import picocli.shell.jline3.PicocliCommands.PicocliCommandsFactory;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -42,7 +43,7 @@ public class Example {
                     ""},
             footer = {"", "Press Ctl-D to exit."},
             subcommands = {
-                    MyCommand.class, CommandLine.HelpCommand.class})
+                    MyCommand.class, PicocliCommands.ClearScreen.class, CommandLine.HelpCommand.class})
     static class CliCommands implements Runnable {
         PrintWriter out;
 
@@ -136,7 +137,13 @@ public class Example {
             builtins.alias("bindkey", "keymap");
             // set up picocli commands
             CliCommands commands = new CliCommands();
-            CommandLine cmd = new CommandLine(commands);
+            
+            PicocliCommandsFactory factory = new PicocliCommandsFactory();
+            // Or, if you have your own factory, you can chain them like this:
+            // MyCustomFactory customFactory = createCustomFactory(); // your application custom factory
+            // PicocliCommands.Factory factory = new PicocliCommands.Factory(customFactory); // chain the factories
+            
+            CommandLine cmd = new CommandLine(commands, factory);
             PicocliCommands picocliCommands = new PicocliCommands(Example::workDir, cmd);
 
             Parser parser = new DefaultParser();
@@ -152,7 +159,7 @@ public class Example {
                         .variable(LineReader.LIST_MAX, 50)   // max tab completion candidates
                         .build();
                 builtins.setLineReader(reader);
-                picocliCommands.includeClearScreenCommand(reader);
+                factory.setLineReader(reader);
                 TailTipWidgets widgets = new TailTipWidgets(reader, systemRegistry::commandDescription, 5, TailTipWidgets.TipType.COMPLETER);
                 widgets.enable();
                 KeyMap<Binding> keyMap = reader.getKeyMaps().get("main");

--- a/picocli-shell-jline3/src/test/java/picocli/shell/jline3/example/Example.java
+++ b/picocli-shell-jline3/src/test/java/picocli/shell/jline3/example/Example.java
@@ -19,12 +19,11 @@ import picocli.CommandLine.ParentCommand;
 import picocli.shell.jline3.PicocliCommands;
 import picocli.shell.jline3.PicocliCommands.PicocliCommandsFactory;
 
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 /**
  * Example that demonstrates how to build an interactive shell with JLine3 and picocli.
@@ -123,15 +122,12 @@ public class Example {
         }
     }
 
-    private static Path workDir() {
-        return Paths.get(System.getProperty("user.dir"));
-    }
-
     public static void main(String[] args) {
         AnsiConsole.systemInstall();
         try {
+            Supplier<Path> workDir = () -> Paths.get(System.getProperty("user.dir"));
             // set up JLine built-in commands
-            Builtins builtins = new Builtins(Example::workDir, null, null);
+            Builtins builtins = new Builtins(workDir, null, null);
             builtins.rename(Builtins.Command.TTOP, "top");
             builtins.alias("zle", "widget");
             builtins.alias("bindkey", "keymap");
@@ -144,11 +140,11 @@ public class Example {
             // PicocliCommandsFactory factory = new PicocliCommandsFactory(customFactory); // chain the factories
 
             CommandLine cmd = new CommandLine(commands, factory);
-            PicocliCommands picocliCommands = new PicocliCommands(Example::workDir, cmd);
+            PicocliCommands picocliCommands = new PicocliCommands(cmd);
 
             Parser parser = new DefaultParser();
             try (Terminal terminal = TerminalBuilder.builder().build()) {
-                SystemRegistry systemRegistry = new SystemRegistryImpl(parser, terminal, Example::workDir, null);
+                SystemRegistry systemRegistry = new SystemRegistryImpl(parser, terminal, workDir, null);
                 systemRegistry.setCommandRegistries(builtins, picocliCommands);
                 systemRegistry.register("help", picocliCommands);
 


### PR DESCRIPTION
Allow users of picocli-shell-jline3 to use `clear` command and a nicer `help` command.

- The clear screen command is provided out of the box by jline2, and similarly should be built into `picocli.shell.jline3.PicocliCommands`. This change allows users of `PicocliCommands` to include a clear screen command with a single line: `picocliCommands.includeClearScreenCommand(reader);` - see the example.
- The help command is provided by jline3 by default, but picocli help is much nicer. This change allows users of `PicocliCommands` to override the jline3 help command with a single line: `systemRegistry.register("help", picocliCommands);` - see the example.