### PR TITLE
documentation fix: @ParentObject -> @ParentCommand

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -7002,7 +7002,7 @@ Subcommands referenced in a `subcommands` attribute need to have a public no-arg
 
 Prior to picocli 4.2, the declared subcommands were instantiated immediately when the top-level `CommandLine` (the `new CommandLine(new Git())` object in the above example) was constructed.
 
-From picocli 4.2, the declared subcommands are not instantiated until they are matched on the command line, unless they have a `@Spec` or `@ParentObject`-annotated field; these are injected during initialization, and in order to inject them the subcommand is instantiated during initialization.
+From picocli 4.2, the declared subcommands are not instantiated until they are matched on the command line, unless they have a `@Spec` or `@ParentCommand`-annotated field; these are injected during initialization, and in order to inject them the subcommand is instantiated during initialization.
 
 === Subcommands as Methods
 As of picocli 3.6 it is possible to register subcommands in a very compact manner by having a `@Command` class with `@Command`-annotated methods.

--- a/docs/index.html
+++ b/docs/index.html
@@ -10979,7 +10979,7 @@ Command names are case-sensitive by default, but this is <a href="#_case_sensiti
 <p>Prior to picocli 4.2, the declared subcommands were instantiated immediately when the top-level <code>CommandLine</code> (the <code>new CommandLine(new Git())</code> object in the above example) was constructed.</p>
 </div>
 <div class="paragraph">
-<p>From picocli 4.2, the declared subcommands are not instantiated until they are matched on the command line, unless they have a <code>@Spec</code> or <code>@ParentObject</code>-annotated field; these are injected during initialization, and in order to inject them the subcommand is instantiated during initialization.</p>
+<p>From picocli 4.2, the declared subcommands are not instantiated until they are matched on the command line, unless they have a <code>@Spec</code> or <code>@ParentCommand</code>-annotated field; these are injected during initialization, and in order to inject them the subcommand is instantiated during initialization.</p>
 </div>
 </div>
 <div class="sect2">


### PR DESCRIPTION
I find no @ParentObject annotation. Does it need to be replaced by @ParentCommand, as it seems to me it is the right annotation ?