### PR TITLE
JLine: change keystroke syntax 'Ctl-D' to more common used syntax 'Ctrl-D'

### DIFF
--- a/picocli-shell-jline2/README.md
+++ b/picocli-shell-jline2/README.md
@@ -71,7 +71,7 @@ public class Example {
      * Top-level command that just prints help.
      */
     @Command(name = "", description = "Example interactive shell with completion",
-            footer = {"", "Press Ctl-D to exit."},
+            footer = {"", "Press Ctrl-D to exit."},
             subcommands = {MyCommand.class, ClearScreen.class, ReadInteractive.class})
     static class CliCommands implements Runnable {
         final ConsoleReader reader;
@@ -164,7 +164,7 @@ public class Example {
             CommandLine cmd = new CommandLine(commands, factory);
             reader.addCompleter(new PicocliJLineCompleter(cmd.getCommandSpec()));
 
-            // start the shell and process input until the user quits with Ctl-D
+            // start the shell and process input until the user quits with Ctrl-D
             String line;
             while ((line = reader.readLine("prompt> ")) != null) {
                 ArgumentList list = new WhitespaceArgumentDelimiter()

--- a/picocli-shell-jline2/src/test/java/picocli/shell/jline2/example/Example.java
+++ b/picocli-shell-jline2/src/test/java/picocli/shell/jline2/example/Example.java
@@ -27,7 +27,7 @@ public class Example {
      * Top-level command that just prints help.
      */
     @Command(name = "", description = "Example interactive shell with completion",
-            footer = {"", "Press Ctl-D to exit."},
+            footer = {"", "Press Ctrl-D to exit."},
             subcommands = {MyCommand.class, ClearScreen.class, ReadInteractive.class})
     static class CliCommands implements Runnable {
         final ConsoleReader reader;
@@ -120,7 +120,7 @@ public class Example {
             CommandLine cmd = new CommandLine(commands, factory);
             reader.addCompleter(new PicocliJLineCompleter(cmd.getCommandSpec()));
 
-            // start the shell and process input until the user quits with Ctl-D
+            // start the shell and process input until the user quits with Ctrl-D
             String line;
             while ((line = reader.readLine("prompt> ")) != null) {
                 ArgumentList list = new WhitespaceArgumentDelimiter()

--- a/picocli-shell-jline3/README.md
+++ b/picocli-shell-jline3/README.md
@@ -133,7 +133,7 @@ public class Example {
                             "Hit @|magenta <TAB>|@ to see available commands.",
                     "Hit @|magenta ALT-S|@ to toggle tailtips.",
                     ""},
-            footer = {"", "Press Ctl-D to exit."},
+            footer = {"", "Press Ctrl-D to exit."},
             subcommands = {
                     MyCommand.class, PicocliCommands.ClearScreen.class, CommandLine.HelpCommand.class})
     static class CliCommands implements Runnable {

--- a/picocli-shell-jline3/src/test/java/picocli/shell/jline3/example/Example.java
+++ b/picocli-shell-jline3/src/test/java/picocli/shell/jline3/example/Example.java
@@ -43,7 +43,7 @@ public class Example {
                             "Hit @|magenta <TAB>|@ to see available commands.",
                             "Hit @|magenta ALT-S|@ to toggle tailtips.",
                     ""},
-            footer = {"", "Press Ctl-D to exit."},
+            footer = {"", "Press Ctrl-D to exit."},
             subcommands = {
                     MyCommand.class, PicocliCommands.ClearScreen.class, CommandLine.HelpCommand.class})
     static class CliCommands implements Runnable {


### PR DESCRIPTION
Though certainly not wrong, `Ctl-D` seems to be rarely used, so I propose to change it to `Ctrl-D` ( that's what I see on English keyboards and in many other places).