### PR TITLE
[#1291] build.gradle for 'picocli-shell-jline3' submodule is changed: Gradle configuration is switched (from 'implementation' to 'api') for 'org.jline:jline' dependency

### DIFF
--- a/picocli-shell-jline3/build.gradle
+++ b/picocli-shell-jline3/build.gradle
@@ -13,7 +13,7 @@ targetCompatibility = 1.8
 
 dependencies {
     implementation     rootProject
-    implementation     "org.jline:jline:$jline3Version"
+    api                "org.jline:jline:$jline3Version"
     implementation     "org.jline:jline-console:$jline3Version"
     testImplementation "junit:junit:$junitVersion"
 }


### PR DESCRIPTION

note: solves broken build issues for any Maven project that uses 'picocli-shell-jline3' version 4.6.0

related issue: https://github.com/remkop/picocli/issues/1291 **_Cannot compile with picocli-shell-jline3 dependency using Maven_**