### PR TITLE
CAUTION admonitions, Kotlin code sample

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1404,6 +1404,8 @@ This may also be useful for applications that need a custom type converter but w
 
 Type converters declared with the `converter` attribute need to have a public no-argument constructor to be instantiated, unless a <<Custom Factory>> is installed to instantiate classes.
 
+CAUTION: If your type converter is declared as nested class, make sure you mark this class as `static`, or picocli will not be able to instantiate your nested converter class without a <<Custom Factory>>.
+
 === Arrays, Collections, Maps
 NOTE: Starting from picocli 2.0, the `type` attribute is no longer necessary for `Collection` and `Map` fields:
 picocli will infer the collection element type from the generic type.
@@ -10186,6 +10188,7 @@ class Dynamic {
 
 All transformers are called once, after the full command hierarchy is constructed, and before any command line arguments are parsed.
 
+CAUTION: If your model transformer is declared as nested class, make sure you mark this class as `static`, or picocli will not be able to instantiate your transformer class without a <<Custom Factory>>.
 
 === Automatic Parameter Indexes
 ==== Automatic Indexes

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1249,6 +1249,30 @@ class SetPositionCommand {
 }
 ----
 
+.Kotlin
+[source,kotlin,role="secondary"]
+----
+@Command(name = "set-position")
+class SetPositionCommand {
+    @Parameters(parameterConsumer = PointConverter::class)
+    private lateinit var position: Point
+
+    class PointConverter : IParameterConsumer {
+        override fun consumeParameters(args: Stack<String>,
+                                       argSpec: ArgSpec,
+                                       commandSpec: CommandSpec) {
+            if (args.size < 2) {
+                throw ParameterException(commandSpec.commandLine(),
+                    "Missing coordinates for Point. Please specify 2 coordinates.")
+            }
+            val x = args.pop().toInt()
+            val y = args.pop().toInt()
+            argSpec.setValue(Point(x, y))
+        }
+    }
+}
+----
+
 See the sections on <<Custom Parameter Processing>> for more details.
 
 CAUTION: Make sure any nested classes are `static`, or picocli will not be able to instantiate them without a <<Custom Factory>>.
@@ -7783,7 +7807,7 @@ class App implements Runnable {
          description = ["App description"],
          footerHeading = "Copyright%n", footer = ["(c) Copyright by the authors"],
          showAtFileInUsageHelp = true)
-class AppKt : Runnable {
+class App : Runnable {
     @Option(names = ["-x"]) var x = 0
 
     override fun run() { println("Hello from app!\nx = $x") }


### PR DESCRIPTION
- Adding CAUTION admonitions about the use of static classes to ITypeConverter and IModelTransformer (#1297)
- Manual, chapter '4.2.2 Multi Parameter Type Converters': adding Kotlin version for code sample

