### PR TITLE
Fix use of deprecated Maven properties

### DIFF
--- a/picocli-codegen/README.adoc
+++ b/picocli-codegen/README.adoc
@@ -190,7 +190,7 @@ The picocli annotation processor supports the options below.
 
 The generated files are written to `META-INF/native-image/picocli-generated/${project}`.
 
-The `project` option can be omitted, but it is a good idea to specify the `project` option with a unique value for your project (e.g. `${groupId}/${artifactId}`) if your jar may be https://stackoverflow.com/a/49811665[shaded] with other jars into an uberjar.
+The `project` option can be omitted, but it is a good idea to specify the `project` option with a unique value for your project (e.g. `${project.groupId}/${project.artifactId}`) if your jar may be https://stackoverflow.com/a/49811665[shaded] with other jars into an uberjar.
 
 
 ==== Other Options
@@ -227,7 +227,7 @@ To set an annotation processor option in Maven, you need to use the `maven-compi
       <version>${maven-compiler-plugin-version}</version>
       <configuration>
         <compilerArgs>
-          <arg>-Aproject=${groupId}/${artifactId}</arg>
+          <arg>-Aproject=${project.groupId}/${project.artifactId}</arg>
         </compilerArgs>
       </configuration>
     </plugin>


### PR DESCRIPTION
Fix the following warnings in Maven when using configuration specified in codegen documentation:
```
The expression ${groupId} is deprecated. Please use ${project.groupId} instead.
The expression ${artifactId} is deprecated. Please use ${project.artifactId} instead.
It is highly recommended to fix these problems because they threaten the stability of your build.
For this reason, future Maven versions might no longer support building such malformed projects.
```