### PR TITLE
chore: fix incorrect version in MANIFEST.MF

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -208,10 +208,10 @@ jar {
     manifest {
         attributes 'Specification-Title'   : 'picocli',
                    'Specification-Vendor'  : 'Remko Popma',
-                   'Specification-Version' : archiveVersion,
+                   'Specification-Version' : archiveVersion.get(),
                    'Implementation-Title'  : 'picocli',
                    'Implementation-Vendor' : 'Remko Popma',
-                   'Implementation-Version': archiveVersion,
+                   'Implementation-Version': archiveVersion.get(),
                    'Main-Class'            : 'picocli.AutoComplete'
     }
     // copy module-info.class to META-INF/versions/9

--- a/picocli-annotation-processing-tests/build.gradle
+++ b/picocli-annotation-processing-tests/build.gradle
@@ -25,10 +25,10 @@ jar {
     manifest {
         attributes 'Specification-Title': 'Picocli Annotation Processing Tests',
                 'Specification-Vendor'  : 'Remko Popma',
-                'Specification-Version' : archiveVersion,
+                'Specification-Version' : archiveVersion.get(),
                 'Implementation-Title'  : 'Picocli Annotation Processing Tests',
                 'Implementation-Vendor' : 'Remko Popma',
-                'Implementation-Version': archiveVersion,
+                'Implementation-Version': archiveVersion.get(),
                 'Automatic-Module-Name' : 'info.picocli.annotation.processing.tests'
     }
 }

--- a/picocli-codegen/build.gradle
+++ b/picocli-codegen/build.gradle
@@ -36,10 +36,10 @@ jar {
     manifest {
         attributes 'Specification-Title'   : 'Picocli Code Generation',
                    'Specification-Vendor'  : 'Remko Popma',
-                   'Specification-Version' : archiveVersion,
+                   'Specification-Version' : archiveVersion.get(),
                    'Implementation-Title'  : 'Picocli Code Generation',
                    'Implementation-Vendor' : 'Remko Popma',
-                   'Implementation-Version': archiveVersion,
+                   'Implementation-Version': archiveVersion.get(),
                    'Automatic-Module-Name' : 'info.picocli.codegen'
     }
 }

--- a/picocli-groovy/build.gradle
+++ b/picocli-groovy/build.gradle
@@ -36,10 +36,10 @@ jar {
     manifest {
         attributes  'Specification-Title'   : 'Picocli Groovy',
                     'Specification-Vendor'  : 'Remko Popma',
-                    'Specification-Version' : archiveVersion,
+                    'Specification-Version' : archiveVersion.get(),
                     'Implementation-Title'  : 'Picocli Groovy',
                     'Implementation-Vendor' : 'Remko Popma',
-                    'Implementation-Version': archiveVersion,
+                    'Implementation-Version': archiveVersion.get(),
                     'Automatic-Module-Name' : 'info.picocli.groovy'
     }
 }

--- a/picocli-shell-jline2/build.gradle
+++ b/picocli-shell-jline2/build.gradle
@@ -19,10 +19,10 @@ jar {
     manifest {
         attributes  'Specification-Title'   : 'Picocli Shell JLine2',
                     'Specification-Vendor'  : 'Remko Popma',
-                    'Specification-Version' : archiveVersion,
+                    'Specification-Version' : archiveVersion.get(),
                     'Implementation-Title'  : 'Picocli Shell JLine2',
                     'Implementation-Vendor' : 'Remko Popma',
-                    'Implementation-Version': archiveVersion,
+                    'Implementation-Version': archiveVersion.get(),
                     'Automatic-Module-Name' : 'info.picocli.shell.jline2'
     }
 }

--- a/picocli-shell-jline3/build.gradle
+++ b/picocli-shell-jline3/build.gradle
@@ -22,10 +22,10 @@ jar {
     manifest {
         attributes  'Specification-Title'   : 'Picocli Shell JLine3',
                     'Specification-Vendor'  : 'Remko Popma',
-                    'Specification-Version' : archiveVersion,
+                    'Specification-Version' : archiveVersion.get(),
                     'Implementation-Title'  : 'Picocli Shell JLine3',
                     'Implementation-Vendor' : 'Remko Popma',
-                    'Implementation-Version': archiveVersion,
+                    'Implementation-Version': archiveVersion.get(),
                     'Automatic-Module-Name' : 'info.picocli.shell.jline3'
     }
 }

--- a/picocli-spring-boot-starter/build.gradle
+++ b/picocli-spring-boot-starter/build.gradle
@@ -25,10 +25,10 @@ jar {
     manifest {
         attributes  'Specification-Title'   : 'Picocli Spring Boot Starter',
                     'Specification-Vendor'  : 'Remko Popma',
-                    'Specification-Version' : archiveVersion,
+                    'Specification-Version' : archiveVersion.get(),
                     'Implementation-Title'  : 'Picocli Spring Boot Starter',
                     'Implementation-Vendor' : 'Remko Popma',
-                    'Implementation-Version': archiveVersion,
+                    'Implementation-Version': archiveVersion.get(),
                     'Automatic-Module-Name' : 'info.picocli.spring'
     }
 }


### PR DESCRIPTION
Fix wrong `Implementation-Version` and `Specification-Version` introduced by bdf774e3c1984da1ed7660ea3cacb2760e29edf0 such as (notice the `task ':jar' property 'archiveVersion'`):

```
Implementation-Version: task ':jar' property 'archiveVersion'
Import-Package: groovy.lang
Main-Class: picocli.AutoComplete
Multi-Release: true
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.5))"
Specification-Title: picocli
Specification-Vendor: Remko Popma
Specification-Version: task ':jar' property 'archiveVersion'
```
(from https://repo1.maven.org/maven2/info/picocli/picocli/4.6.1/picocli-4.6.1.jar / `META-INF/MANIFEST.MF`)