### PR TITLE
Upgrade Gradle to 6.8.2 and enable Official Gradle Wrapper Validation GitHub Action

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,10 @@
+name: "Validate Gradle Wrapper"
+on: [ push, pull_request ]
+
+jobs:
+  validation:
+    name: "Validation"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,11 +1,5 @@
-#Mon Apr 24 23:58:38 JST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-#distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
-#distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
-#distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
-#distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-all.zip
-#distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip


### PR DESCRIPTION
Official Gradle Wrapper Validation Action enabled to ensure binary wrapper is not tampered with.

See: https://github.com/marketplace/actions/gradle-wrapper-validation