### PR TITLE
add xref for subcommands

### DIFF
--- a/picocli-codegen/src/main/java/picocli/codegen/docgen/manpage/ManPageGenerator.java
+++ b/picocli-codegen/src/main/java/picocli/codegen/docgen/manpage/ManPageGenerator.java
@@ -656,7 +656,8 @@ public class ManPageGenerator implements Callable<Integer> {
 
             Text namesText = subHelp.commandNamesText(", ");
             String names = namesText.toString();
-            pw.printf("%s::%n", names);
+            String xrefname = makeFileName(subHelp.commandSpec());
+            pw.printf("xref:%s[%s]::%n", xrefname, names);
 
             CommandLine.Model.UsageMessageSpec usage = subHelp.commandSpec().usageMessage();
             String header = !empty(usage.header())

--- a/picocli-codegen/src/test/resources/manpagegenerator/main_class.adoc
+++ b/picocli-codegen/src/test/resources/manpagegenerator/main_class.adoc
@@ -44,7 +44,7 @@ _<file>_::
 // tag::picocli-generated-man-section-commands[]
 == Commands
 
-*gen-manpage*::
+xref:main_class-gen-manpage.adoc[*gen-manpage*]::
   Generates man pages for all commands in the specified directory.
 
 // end::picocli-generated-man-section-commands[]

--- a/picocli-codegen/src/test/resources/manpagegenerator/top-level-command-subcommand.adoc
+++ b/picocli-codegen/src/test/resources/manpagegenerator/top-level-command-subcommand.adoc
@@ -47,7 +47,7 @@ Example subcommand
 // tag::picocli-generated-man-section-commands[]
 == Commands
 
-*gen-manpage*::
+xref:top-level-command-subcommand-gen-manpage.adoc[*gen-manpage*]::
   Generates man pages for all commands in the specified directory.
 
 // end::picocli-generated-man-section-commands[]

--- a/picocli-codegen/src/test/resources/manpagegenerator/top-level-command.adoc
+++ b/picocli-codegen/src/test/resources/manpagegenerator/top-level-command.adoc
@@ -50,10 +50,10 @@ example top-level command
 // tag::picocli-generated-man-section-commands[]
 == Commands
 
-*subcommand*::
+xref:top-level-command-subcommand.adoc[*subcommand*]::
   Example subcommand
 
-*visible*::
+xref:top-level-command-visible.adoc[*visible*]::
   Example visible subcommand
 
 // end::picocli-generated-man-section-commands[]

--- a/picocli-codegen/src/test/resources/testHidden.manpage.adoc
+++ b/picocli-codegen/src/test/resources/testHidden.manpage.adoc
@@ -50,7 +50,7 @@ This app does great things.
 // tag::picocli-generated-man-section-commands[]
 == Commands
 
-*a-sub*::
+xref:testHidden-a-sub.adoc[*a-sub*]::
   A sub command
 
 // end::picocli-generated-man-section-commands[]


### PR DESCRIPTION
subcommands get separate html files, nice if html generated from asciidoc could link them.

Added an xref for each subcommand and updated tests. I believe an xref like this doesn't hurt anything, and helps with linking is possible (html and pdf). That said, I know just enough asciidoc to be dangerous, so... 