### PR TITLE
#1346 path/host completion for custom types

### DIFF
--- a/src/main/java/picocli/AutoComplete.java
+++ b/src/main/java/picocli/AutoComplete.java
@@ -21,15 +21,10 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.net.InetAddress;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.Callable;
 
+import picocli.AutoComplete.TypeCompletionRegistry.CompletionKind;
 import picocli.CommandLine.*;
 import picocli.CommandLine.Model.PositionalParamSpec;
 import picocli.CommandLine.Model.ArgSpec;
@@ -149,9 +144,13 @@ public class AutoComplete {
                         "as the completion script.")
         boolean writeCommandScript;
 
-        @Option(names = {"-p", "--pathCompletionTypes"}, split=",", description = "Comma-separated list of fully "
+        @Option(names = {"--pathCompletionTypes"}, split=",", description = "Comma-separated list of fully "
                 + "qualified custom types for which to delegate to built-in path name completion.")
         List<String> pathCompletionTypes = new ArrayList<String>();
+
+        @Option(names = {"--hostCompletionTypes"}, split=",", description = "Comma-separated list of fully "
+                + "qualified custom types for which to delegate to built-in host name completion.")
+        List<String> hostCompletionTypes = new ArrayList<String>();
 
         @Option(names = {"-f", "--force"}, description = "Overwrite existing script files.")
         boolean overwriteIfExists;
@@ -166,12 +165,7 @@ public class AutoComplete {
             Class<?> cls = Class.forName(commandLineFQCN);
             Object instance = factory.create(cls);
             CommandLine commandLine = new CommandLine(instance, factory);
-            for (String className : pathCompletionTypes) {
-                // TODO implement error handling if the class is not on the classpath
-                Class<?> pathCompletionClass = Class.forName(className);
-                commandLine.registerForPathCompletion(pathCompletionClass);
-            }
-
+            TypeCompletionRegistry registry = typeCompletionRegistry(pathCompletionTypes, hostCompletionTypes);
             if (commandName == null) {
                 commandName = commandLine.getCommandName(); //new CommandLine.Help(commandLine.commandDescriptor).commandName;
                 if (CommandLine.Help.DEFAULT_COMMAND_NAME.equals(commandName)) {
@@ -192,8 +186,25 @@ public class AutoComplete {
                 return EXIT_CODE_COMPLETION_SCRIPT_EXISTS;
             }
 
-            AutoComplete.bash(commandName, autoCompleteScript, commandScript, commandLine);
+            AutoComplete.bash(commandName, autoCompleteScript, commandScript, commandLine, registry);
             return EXIT_CODE_SUCCESS;
+        }
+
+        private static TypeCompletionRegistry typeCompletionRegistry(List<String> pathCompletionTypes, List<String> hostCompletionTypes)
+                throws ClassNotFoundException {
+            TypeCompletionRegistry registry = new TypeCompletionRegistry();
+            addToRegistry(registry, pathCompletionTypes, CompletionKind.FILE);
+            addToRegistry(registry, hostCompletionTypes, CompletionKind.HOST);
+            return registry;
+        }
+
+        private static void addToRegistry(TypeCompletionRegistry registry, List<String> types,
+                CompletionKind kind) throws ClassNotFoundException {
+            for (String type : types) {
+                // TODO implement error handling if the class is not on the classpath
+                Class<?> cls = Class.forName(type);
+                registry.registerType(cls, kind);
+            }
         }
 
         private boolean checkExists(final File file) {
@@ -204,6 +215,90 @@ public class AutoComplete {
                 return true;
             }
             return false;
+        }
+    }
+
+    /**
+     * Meta-information about FQCN to {@link CompletionKind} mappings.
+     */
+    public static class TypeCompletionRegistry {
+
+        /**
+         * The different kinds of supported auto completion mechanisms.
+         */
+        public enum CompletionKind {
+            /**
+             * Auto completion resolved against paths on the file system.
+             */
+            FILE,
+            /**
+             * Auto completion resolved against known hosts.
+             */
+            HOST,
+            /**
+             * No auto-completion.
+             */
+            NONE
+        }
+
+        private final Map<String, CompletionKind> registry = new HashMap<String, CompletionKind>();
+
+        public TypeCompletionRegistry() {
+            registerDefaultPathCompletionTypes();
+            registerDefaultHostCompletionTypes();
+        }
+
+        private void registerDefaultPathCompletionTypes() {
+            registry.put(File.class.getName(), CompletionKind.FILE);
+            registry.put("java.nio.file.Path", CompletionKind.FILE);
+        }
+
+        private void registerDefaultHostCompletionTypes() {
+            registry.put(InetAddress.class.getName(), CompletionKind.HOST);
+        }
+
+        /**
+         * <p>Register the type {@code type} to the given {@link CompletionKind}.</p>
+         * <p>Built-in supported types to {@link CompletionKind} mappings are:
+         * <ul>
+         *     <li>{@link CompletionKind#FILE}:
+         *         <ul>
+         *             <li>{@link java.io.File}</li>
+         *             <li>{@link java.nio.file.Path}</li>
+         *         </ul>
+         *     </li>
+         *     <li>{@link CompletionKind#HOST}:
+         *         <ul>
+         *             <li>{@link java.net.InetAddress}</li>
+         *         </ul>
+         *     </li>
+         * </ul>
+         * </p>
+         *
+         * @param type the type to register
+         * @param kind the kind of completion to apply for this type
+         * @return this {@link TypeCompletionRegistry} object, to allow method chaining
+         * @see #forType(Class)
+         */
+        public <K> TypeCompletionRegistry registerType(Class<K> type, CompletionKind kind) {
+            registry.put(type.getName(), kind);
+            return this;
+        }
+
+        /**
+         * Returns the {@link CompletionKind} for the requested {@code type} or {@link CompletionKind#NONE} if no
+         * mapping exists.
+         * @param type the type to retrieve the {@link CompletionKind} for.
+         * @return the {@link CompletionKind} for the requested {@code type} or {@link CompletionKind#NONE} if no
+         * mapping exists.
+         * @see #registerType(Class, CompletionKind)
+         */
+        public CompletionKind forType(Class<?> type) {
+            CompletionKind kind = registry.get(type.getName());
+            if (kind == null) {
+                return CompletionKind.NONE;
+            }
+            return kind;
         }
     }
 
@@ -442,7 +537,23 @@ public class AutoComplete {
      * @throws IOException if a problem occurred writing to the specified files
      */
     public static void bash(String scriptName, File out, File command, CommandLine commandLine) throws IOException {
-        String autoCompleteScript = bash(scriptName, commandLine);
+        bash(scriptName, out, command, commandLine, new TypeCompletionRegistry());
+    }
+
+    /**
+     * Generates source code for an autocompletion bash script for the specified picocli-based application,
+     * and writes this script to the specified {@code out} file, and optionally writes an invocation script
+     * to the specified {@code command} file.
+     * @param scriptName the name of the command to generate a bash autocompletion script for
+     * @param commandLine the {@code CommandLine} instance for the command line application
+     * @param out the file to write the autocompletion bash script source code to
+     * @param command the file to write a helper script to that invokes the command, or {@code null} if no helper script file should be written
+     * @param registry the custom types to completions kind registry
+     * @throws IOException if a problem occurred writing to the specified files
+     */
+    public static void bash(String scriptName, File out, File command, CommandLine commandLine,
+            TypeCompletionRegistry registry) throws IOException {
+        String autoCompleteScript = bash(scriptName, commandLine, registry);
         Writer completionWriter = null;
         Writer scriptWriter = null;
         try {
@@ -471,6 +582,17 @@ public class AutoComplete {
      * @return source code for an autocompletion bash script
      */
     public static String bash(String scriptName, CommandLine commandLine) {
+        return bash(scriptName, commandLine, new TypeCompletionRegistry());
+    }
+
+    /**
+     * Generates and returns the source code for an autocompletion bash script for the specified picocli-based application.
+     * @param scriptName the name of the command to generate a bash autocompletion script for
+     * @param commandLine the {@code CommandLine} instance for the command line application
+     * @param registry the custom types to completions kind registry
+     * @return source code for an autocompletion bash script
+     */
+    public static String bash(String scriptName, CommandLine commandLine, TypeCompletionRegistry registry) {
         if (scriptName == null)  { throw new NullPointerException("scriptName"); }
         if (commandLine == null) { throw new NullPointerException("commandLine"); }
         StringBuilder result = new StringBuilder();
@@ -481,7 +603,8 @@ public class AutoComplete {
 
         for (CommandDescriptor descriptor : hierarchy) {
             if (descriptor.commandLine.getCommandSpec().usageMessage().hidden()) { continue; } // #887 skip hidden subcommands
-            result.append(generateFunctionForCommand(descriptor.functionName, descriptor.commandName, descriptor.commandLine));
+            result.append(generateFunctionForCommand(descriptor.functionName, descriptor.commandName,
+                    descriptor.commandLine, registry));
         }
         result.append(format(SCRIPT_FOOTER, scriptName));
         return result.toString();
@@ -592,7 +715,8 @@ public class AutoComplete {
         return sb.append(normalize.apply(lastValue)).toString();
     }
 
-    private static String generateFunctionForCommand(String functionName, String commandName, CommandLine commandLine) {
+    private static String generateFunctionForCommand(String functionName, String commandName, CommandLine commandLine,
+            TypeCompletionRegistry registry) {
         String FUNCTION_HEADER = "" +
                 "\n" +
                 "# Generates completions for the options and subcommands of the `%s` %scommand.\n" +
@@ -660,7 +784,7 @@ public class AutoComplete {
         // sql.Types?
 
         // Now generate the "case" switches for the options whose arguments we can generate completions for
-        buff.append(generateOptionsSwitch(commandLine, argOptionFields));
+        buff.append(generateOptionsSwitch(registry, argOptionFields));
 
         // Generate completion lists for positional params with a known set of valid values (including java enums)
         for (PositionalParamSpec f : commandSpec.positionalParameters()) {
@@ -669,7 +793,7 @@ public class AutoComplete {
             }
         }
 
-        String paramsCases = generatePositionalParamsCases(commandLine, commandSpec.positionalParameters(), "", "${curr_word}");
+        String paramsCases = generatePositionalParamsCases(registry, commandSpec.positionalParameters(), "", "${curr_word}");
         String posParamsFooter = "";
         if (paramsCases.length() > 0) {
             String POSITIONAL_PARAMS_FOOTER = "" +
@@ -706,7 +830,7 @@ public class AutoComplete {
     }
 
     private static String generatePositionalParamsCases(
-            CommandLine commandLine, List<PositionalParamSpec> posParams, String indent, String currWord) {
+            TypeCompletionRegistry registry, List<PositionalParamSpec> posParams, String indent, String currWord) {
         StringBuilder buff = new StringBuilder(1024);
         for (PositionalParamSpec param : posParams) {
             if (param.hidden()) { continue; } // #887 skip hidden params
@@ -721,11 +845,11 @@ public class AutoComplete {
             if (param.completionCandidates() != null) {
                 buff.append(format("%s    %s (( currIndex >= %d && currIndex <= %d )); then\n", indent, ifOrElif, min, max));
                 buff.append(format("%s      positionals=$( compgen -W \"$%s_pos_param_args\" -- \"%s\" )\n", indent, paramName, currWord));
-            } else if (commandLine.supportsPathCompletion(type)) {
+            } else if (registry.forType(type) == CompletionKind.FILE) {
                 buff.append(format("%s    %s (( currIndex >= %d && currIndex <= %d )); then\n", indent, ifOrElif, min, max));
                 buff.append(format("%s      compopt -o filenames\n", indent));
                 buff.append(format("%s      positionals=$( compgen -f -- \"%s\" ) # files\n", indent, currWord));
-            } else if (type.equals(InetAddress.class)) {
+            } else if (registry.forType(type) == CompletionKind.HOST) {
                 buff.append(format("%s    %s (( currIndex >= %d && currIndex <= %d )); then\n", indent, ifOrElif, min, max));
                 buff.append(format("%s      compopt -o filenames\n", indent));
                 buff.append(format("%s      positionals=$( compgen -A hostname -- \"%s\" )\n", indent, currWord));
@@ -737,8 +861,8 @@ public class AutoComplete {
         return buff.toString();
     }
 
-    private static String generateOptionsSwitch(CommandLine commandLine, List<OptionSpec> argOptions) {
-        String optionsCases = generateOptionsCases(commandLine, argOptions, "", "${curr_word}");
+    private static String generateOptionsSwitch(TypeCompletionRegistry registry, List<OptionSpec> argOptions) {
+        String optionsCases = generateOptionsCases(registry, argOptions, "", "${curr_word}");
 
         if (optionsCases.length() == 0) {
             return "";
@@ -753,7 +877,7 @@ public class AutoComplete {
     }
 
     private static String generateOptionsCases(
-            CommandLine commandLine, List<OptionSpec> argOptionFields, String indent, String currWord) {
+            TypeCompletionRegistry registry, List<OptionSpec> argOptionFields, String indent, String currWord) {
         StringBuilder buff = new StringBuilder(1024);
         for (OptionSpec option : argOptionFields) {
             if (option.hidden()) { continue; } // #887 skip hidden options
@@ -766,19 +890,19 @@ public class AutoComplete {
                 buff.append(format("%s      COMPREPLY=( $( compgen -W \"${%s_option_args}\" -- \"%s\" ) )\n", indent, bashify(option.paramLabel()), currWord));
                 buff.append(format("%s      return $?\n", indent));
                 buff.append(format("%s      ;;\n", indent));
-            } else if (commandLine.supportsPathCompletion(type)) {
+            } else if (registry.forType(type) == CompletionKind.FILE) {
                 buff.append(format("%s    %s)\n", indent, concat("|", option.names()))); // "    -f|--file)\n"
                 buff.append(format("%s      compopt -o filenames\n", indent));
                 buff.append(format("%s      COMPREPLY=( $( compgen -f -- \"%s\" ) ) # files\n", indent, currWord));
                 buff.append(format("%s      return $?\n", indent));
                 buff.append(format("%s      ;;\n", indent));
-            } else if (type.equals(InetAddress.class)) {
+            } else if (registry.forType(type) == CompletionKind.HOST) {
                 buff.append(format("%s    %s)\n", indent, concat("|", option.names()))); // "    -h|--host)\n"
                 buff.append(format("%s      compopt -o filenames\n", indent));
                 buff.append(format("%s      COMPREPLY=( $( compgen -A hostname -- \"%s\" ) )\n", indent, currWord));
                 buff.append(format("%s      return $?\n", indent));
                 buff.append(format("%s      ;;\n", indent));
-            } else {
+            } else if (registry.forType(type) == CompletionKind.NONE) {
                 buff.append(format("%s    %s)\n", indent, concat("|", option.names()))); // no completions available
                 buff.append(format("%s      return\n", indent));
                 buff.append(format("%s      ;;\n", indent));

--- a/src/main/java/picocli/AutoComplete.java
+++ b/src/main/java/picocli/AutoComplete.java
@@ -149,7 +149,7 @@ public class AutoComplete {
                         "as the completion script.")
         boolean writeCommandScript;
 
-        @Option(names = {"-p", "--pathTypes"}, split=",", description = "Comma-separated list of fully "
+        @Option(names = {"-p", "--pathCompletionTypes"}, split=",", description = "Comma-separated list of fully "
                 + "qualified custom types for which to delegate to built-in path name completion.")
         List<String> pathCompletionTypes = new ArrayList<String>();
 

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -150,7 +150,6 @@ public class CommandLine {
     private final Tracer tracer = new Tracer();
     private CommandSpec commandSpec;
     private final Interpreter interpreter;
-    private final Set<String> pathCompletionTypes = new HashSet<String>();
     private final IFactory factory;
 
     private Object executionResult;
@@ -230,12 +229,6 @@ public class CommandLine {
         if (userCalled) { this.applyModelTransformations(); }
         commandSpec.validate();
         if (commandSpec.unmatchedArgsBindings().size() > 0) { setUnmatchedArgumentsAllowed(true); }
-        registerDefaultPathCompletionTypes();
-    }
-
-    private void registerDefaultPathCompletionTypes() {
-        pathCompletionTypes.add("java.io.File");
-        pathCompletionTypes.add("java.nio.file.Path");
     }
 
     /** Apply transformers to command spec recursively. */
@@ -260,8 +253,6 @@ public class CommandLine {
 
         result.interpreter.converterRegistry.clear();
         result.interpreter.converterRegistry.putAll(interpreter.converterRegistry);
-        result.pathCompletionTypes.clear();
-        result.pathCompletionTypes.addAll(pathCompletionTypes);
         return result;
     }
 
@@ -3284,39 +3275,6 @@ public class CommandLine {
             command.registerConverter(cls, converter);
         }
         return this;
-    }
-
-    /**
-     * <p>Adds the type {@code type} to the list of supported type for path completion.</p>
-     * <p>Built-in supported types being:
-     * <ul>
-     *   <li>{@link java.io.File}</li>
-     *   <li>{@link java.nio.file.Path}</li>
-     * </ul>
-     * </p>
-     * type {@code type}.
-     * @param type the type to check if path completion is supported for
-     * @return this CommandLine object, to allow method chaining
-     * @see #supportsPathCompletion(Class)
-     */
-    public <K> CommandLine registerForPathCompletion(Class<K> cls) {
-        pathCompletionTypes.add(cls.getName());
-        for (CommandLine command : getCommandSpec().commands.values()) {
-            command.registerForPathCompletion(cls);
-        }
-        return this;
-    }
-
-    /**
-     * Returns {@code true} if the CommandLine supports path completion for {@link Option} and {@link Parameters} of
-     * type {@code type}.
-     * @param type the type to check if path completion is supported for
-     * @return {@code true} if the CommandLine supports path completion for {@link Option} and {@link Parameters} of
-     * type {@code type}.
-     * @see #registerForPathCompletion(Class)
-     */
-    public boolean supportsPathCompletion(Class<?> type) {
-        return pathCompletionTypes.contains(type.getName());
     }
 
     /** Returns the String that separates option names from option values when parsing command line options.

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -150,6 +150,7 @@ public class CommandLine {
     private final Tracer tracer = new Tracer();
     private CommandSpec commandSpec;
     private final Interpreter interpreter;
+    private final Set<String> pathCompletionTypes = new HashSet<String>();
     private final IFactory factory;
 
     private Object executionResult;
@@ -229,6 +230,12 @@ public class CommandLine {
         if (userCalled) { this.applyModelTransformations(); }
         commandSpec.validate();
         if (commandSpec.unmatchedArgsBindings().size() > 0) { setUnmatchedArgumentsAllowed(true); }
+        registerDefaultPathCompletionTypes();
+    }
+
+    private void registerDefaultPathCompletionTypes() {
+        pathCompletionTypes.add("java.io.File");
+        pathCompletionTypes.add("java.nio.file.Path");
     }
 
     /** Apply transformers to command spec recursively. */
@@ -253,6 +260,8 @@ public class CommandLine {
 
         result.interpreter.converterRegistry.clear();
         result.interpreter.converterRegistry.putAll(interpreter.converterRegistry);
+        result.pathCompletionTypes.clear();
+        result.pathCompletionTypes.addAll(pathCompletionTypes);
         return result;
     }
 
@@ -3275,6 +3284,39 @@ public class CommandLine {
             command.registerConverter(cls, converter);
         }
         return this;
+    }
+
+    /**
+     * <p>Adds the type {@code type} to the list of supported type for path completion.</p>
+     * <p>Built-in supported types being:
+     * <ul>
+     *   <li>{@link java.io.File}</li>
+     *   <li>{@link java.nio.file.Path}</li>
+     * </ul>
+     * </p>
+     * type {@code type}.
+     * @param type the type to check if path completion is supported for
+     * @return this CommandLine object, to allow method chaining
+     * @see #supportsPathCompletion(Class)
+     */
+    public <K> CommandLine registerForPathCompletion(Class<K> cls) {
+        pathCompletionTypes.add(cls.getName());
+        for (CommandLine command : getCommandSpec().commands.values()) {
+            command.registerForPathCompletion(cls);
+        }
+        return this;
+    }
+
+    /**
+     * Returns {@code true} if the CommandLine supports path completion for {@link Option} and {@link Parameters} of
+     * type {@code type}.
+     * @param type the type to check if path completion is supported for
+     * @return {@code true} if the CommandLine supports path completion for {@link Option} and {@link Parameters} of
+     * type {@code type}.
+     * @see #registerForPathCompletion(Class)
+     */
+    public boolean supportsPathCompletion(Class<?> type) {
+        return pathCompletionTypes.contains(type.getName());
     }
 
     /** Returns the String that separates option names from option values when parsing command line options.

--- a/src/test/java/picocli/AutoCompleteTest.java
+++ b/src/test/java/picocli/AutoCompleteTest.java
@@ -15,6 +15,7 @@
  */
 package picocli;
 
+import java.util.regex.Pattern;
 import org.hamcrest.CoreMatchers;
 import org.junit.Rule;
 import org.junit.Test;
@@ -247,7 +248,8 @@ public class AutoCompleteTest {
 
     private static final String AUTO_COMPLETE_APP_USAGE = String.format("" +
             "Usage: picocli.AutoComplete [-fhVw] [-c=<factoryClass>] [-n=<commandName>]%n" +
-            "                            [-o=<autoCompleteScript>] [@<filename>...]%n" +
+            "                            [-o=<autoCompleteScript>] [-p=<pathCompletionTypes>%n" +
+            "                            [,<pathCompletionTypes>...]]... [@<filename>...]%n" +
             "                            <commandLineFQCN>%n" +
             "Generates a bash completion script for the specified command class.%n" +
             "      [@<filename>...]       One or more argument files containing options.%n" +
@@ -272,6 +274,10 @@ public class AutoCompleteTest {
             "                               the current directory.%n" +
             "  -w, --writeCommandScript   Write a '<commandName>' sample command script to%n" +
             "                               the same directory as the completion script.%n" +
+            "  -p, --pathCompletionTypes=<pathCompletionTypes>[,<pathCompletionTypes>...]%n" +
+            "                             Comma-separated list of fully qualified custom%n" +
+            "                               types for which to delegate to built-in path%n" +
+            "                               name completion.%n" +
             "  -f, --force                Overwrite existing script files.%n" +
             "  -h, --help                 Show this help message and exit.%n" +
             "  -V, --version              Print version information and exit.%n" +
@@ -761,7 +767,7 @@ public class AutoCompleteTest {
                 "\n" +
                 "  local commands=\"\"\n" +
                 "  local flag_opts=\"-w --writeCommandScript -f --force -h --help -V --version\"\n" +
-                "  local arg_opts=\"-c --factory -n --name -o --completionScript\"\n" +
+                "  local arg_opts=\"-c --factory -n --name -o --completionScript -p --pathCompletionTypes\"\n" +
                 "\n" +
                 "  compopt +o default\n" +
                 "\n" +
@@ -776,6 +782,9 @@ public class AutoCompleteTest {
                 "      compopt -o filenames\n" +
                 "      COMPREPLY=( $( compgen -f -- \"${curr_word}\" ) ) # files\n" +
                 "      return $?\n" +
+                "      ;;\n" +
+                "    -p|--pathCompletionTypes)\n" +
+                "      return\n" +
                 "      ;;\n" +
                 "  esac\n" +
                 "\n" +
@@ -1821,6 +1830,112 @@ public class AutoCompleteTest {
     @Command(name = "Level1", subcommands = {NestedLevel2.class})
     static class NestedLevel1 implements Runnable {
         public void run() {
+        }
+
+    }
+
+    @Test
+    public void testPathCompletionOnCustomTypes() throws IOException {
+        final String commandName = "bestCommandEver";
+        final File completionScript = new File(commandName + "_completion");
+        if (completionScript.exists()) {assertTrue(completionScript.delete());}
+        completionScript.deleteOnExit();
+
+        AutoComplete.main(String.format("--name=%s", commandName),
+                String.format("--pathCompletionTypes=%s,%s",
+                        PathCompletionCommand.CustomPath1.class.getName(),
+                        PathCompletionCommand.CustomPath2.class.getName()),
+                "picocli.AutoCompleteTest$PathCompletionCommand");
+
+        byte[] completion = readBytes(completionScript);
+        assertTrue(completionScript.delete());
+
+        String expected = expectedCommandCompletion(commandName,
+                "function _picocli_bestCommandEver() {\n" +
+                        "  # Get completion data\n" +
+                        "  local curr_word=${COMP_WORDS[COMP_CWORD]}\n" +
+                        "  local prev_word=${COMP_WORDS[COMP_CWORD-1]}\n" +
+                        "\n" +
+                        "  local commands=\"\"\n" +
+                        "  local flag_opts=\"\"\n" +
+                        "  local arg_opts=\"--file --custom-path-1 --custom-path-2 --custom-type\"\n" +
+                        "\n" +
+                        "  compopt +o default\n" +
+                        "\n" +
+                        "  case ${prev_word} in\n" +
+                        "    --file)\n" +
+                        "      compopt -o filenames\n" +
+                        "      COMPREPLY=( $( compgen -f -- \"${curr_word}\" ) ) # files\n" +
+                        "      return $?\n" +
+                        "      ;;\n" +
+                        "    --custom-path-1)\n" +
+                        "      compopt -o filenames\n" +
+                        "      COMPREPLY=( $( compgen -f -- \"${curr_word}\" ) ) # files\n" +
+                        "      return $?\n" +
+                        "      ;;\n" +
+                        "    --custom-path-2)\n" +
+                        "      compopt -o filenames\n" +
+                        "      COMPREPLY=( $( compgen -f -- \"${curr_word}\" ) ) # files\n" +
+                        "      return $?\n" +
+                        "      ;;\n" +
+                        "    --custom-type)\n" +
+                        "      return\n" +
+                        "      ;;\n" +
+                        "  esac\n" +
+                        "\n" +
+                        "  if [[ \"${curr_word}\" == -* ]]; then\n" +
+                        "    COMPREPLY=( $(compgen -W \"${flag_opts} ${arg_opts}\" -- \"${curr_word}\") )\n" +
+                        "  else\n" +
+                        "    local positionals=\"\"\n" +
+                        "    COMPREPLY=( $(compgen -W \"${commands} ${positionals}\" -- \"${curr_word}\") )\n" +
+                        "  fi\n" +
+                        "}\n");
+
+        assertEquals(expected, new String(completion, "UTF8"));
+    }
+
+    private String expectedCommandCompletion(String commandName, String autoCompleteFunctionContent) {
+        String expected = expectedCompletionScriptForAutoCompleteApp()
+                .replaceAll("picocli\\.AutoComplete", commandName);
+        expected = Pattern.compile("function _picocli_" + commandName + "\\(\\) \\{\n"
+                + "(.+)\n"
+                + "}\n"
+                + "\n"
+                + "# Define a completion specification \\(a compspec\\) for the", Pattern.DOTALL)
+                .matcher(expected)
+                .replaceFirst(autoCompleteFunctionContent.replace("$", "\\$") +
+                        "\n# Define a completion specification (a compspec) for the");
+        return expected;
+    }
+
+    @Command(name = "PathCompletion")
+    static class PathCompletionCommand implements Runnable {
+
+        @Option(names = "--file")
+        private File file;
+
+        @Option(names = "--custom-path-1")
+        private CustomPath1 customPath1;
+
+        @Option(names = "--custom-path-2")
+        private List<CustomPath2> customPath2;
+
+        @Option(names = "--custom-type")
+        private CustomType customType;
+
+        public void run() {
+        }
+
+        static class CustomPath1 {
+            String value;
+        }
+
+        static class CustomPath2 {
+            String value;
+        }
+
+        static class CustomType {
+            String value;
         }
     }
 }


### PR DESCRIPTION
This is an early PR for issue https://github.com/remkop/picocli/issues/1346
The goal is to ask for feedback before going further.

I haven't found a `CONTRIBUTING.md`, therefore I have a few process oriented questions.
* What is the java version to use? I saw some java 5 mentioned in the `build.gradle`, but it seems travis only builds on JDK 8 and above?
* Is there a commit/branch/pr naming convention?
* How to write tests/which level of testing is deemed acceptable?

Concerning the issue in itself, I used a slightly different approach to avoid to pass the extra argument all the way around in the `AutoComplete` command.
This has the advantage that in case the auto-complete is embed as a subcommand, it is possible to programmatically register the path completion types as done for the type converters.

The path completion types are directly stored in the `CommandLine` and not in the `Interpreter` as I thought it is does not belong to the interpreter. But I'm not 100% sure of what the interpreter is, so let me know if you think I should move it inside.

What remains to be done:
* `AutoComplete` error handling in case the class is not found in the classpath
* Writing unit tests for the additional `CommandLine` methods
* Writing additional integration tests (subcommands for example)
* Updating documentation to mention this new feature and how to use it

What does not work:
* I did a quick test and the completion of path list only works for the first argument. There is no completion given for the second and I suspect it's also not working with a separator. But this is way out of scope of this issue/pr

Let me know what you think of the current approach and I'll move forward with your feedback

Regards,