### PR TITLE
Fix #1351

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -8680,16 +8680,17 @@ public class CommandLine {
             private String[] expandVariables(String[] desc) {
                 if (desc.length == 0) { return desc; }
                 StringBuilder candidates = new StringBuilder();
-                if (completionCandidates() != null) {
-                    boolean isCompletionCandidatesUsed = false;
-                    for (String s: desc) {
-                        if (s.contains(DESCRIPTION_VARIABLE_COMPLETION_CANDIDATES)) {
-                            isCompletionCandidatesUsed = true;
-                            break;
-                        }
+                boolean isCompletionCandidatesUsed = false;
+                for (String s: desc) {
+                    if (s.contains(DESCRIPTION_VARIABLE_COMPLETION_CANDIDATES)) {
+                        isCompletionCandidatesUsed = true;
+                        break;
                     }
-                    if (isCompletionCandidatesUsed){
-                        for (String c : completionCandidates()) {
+                }
+                if (isCompletionCandidatesUsed) {
+                    Iterable<String> iter = completionCandidates();
+                    if (iter != null) {
+                        for (String c : iter) {
                             if (candidates.length() > 0) { candidates.append(", "); }
                             candidates.append(c);
                         }

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -8680,7 +8680,16 @@ public class CommandLine {
             private String[] expandVariables(String[] desc) {
                 if (desc.length == 0) { return desc; }
                 StringBuilder candidates = new StringBuilder();
-                if (completionCandidates() != null) {
+
+                boolean flag = false;
+                for (String s: desc) {
+                    if (s.contains(DESCRIPTION_VARIABLE_COMPLETION_CANDIDATES)) {
+                        flag = true;
+                        break;
+                    }
+                }
+
+                if (completionCandidates() != null && flag) {
                     for (String c : completionCandidates()) {
                         if (candidates.length() > 0) { candidates.append(", "); }
                         candidates.append(c);

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -8680,19 +8680,19 @@ public class CommandLine {
             private String[] expandVariables(String[] desc) {
                 if (desc.length == 0) { return desc; }
                 StringBuilder candidates = new StringBuilder();
-
-                boolean flag = false;
-                for (String s: desc) {
-                    if (s.contains(DESCRIPTION_VARIABLE_COMPLETION_CANDIDATES)) {
-                        flag = true;
-                        break;
+                if (completionCandidates() != null) {
+                    boolean isCompletionCandidatesUsed = false;
+                    for (String s: desc) {
+                        if (s.contains(DESCRIPTION_VARIABLE_COMPLETION_CANDIDATES)) {
+                            isCompletionCandidatesUsed = true;
+                            break;
+                        }
                     }
-                }
-
-                if (completionCandidates() != null && flag) {
-                    for (String c : completionCandidates()) {
-                        if (candidates.length() > 0) { candidates.append(", "); }
-                        candidates.append(c);
+                    if (isCompletionCandidatesUsed){
+                        for (String c : completionCandidates()) {
+                            if (candidates.length() > 0) { candidates.append(", "); }
+                            candidates.append(c);
+                        }
                     }
                 }
                 String defaultValueString = defaultValueString(false); // interpolate later

--- a/src/test/java/picocli/Issue1351.java
+++ b/src/test/java/picocli/Issue1351.java
@@ -9,8 +9,7 @@ import java.util.NoSuchElementException;
 import static org.junit.Assert.assertEquals;
 
 public class Issue1351 {
-    static int flag = 0;
-
+    static boolean testUsed;
     static class MyIterator implements Iterator<String> {
         private int cursor;
         private final String[] a;
@@ -22,7 +21,7 @@ public class Issue1351 {
         @Override
         public boolean hasNext() {
             // Do something in the iterator, maybe talking to a server as was mentioned in issue 1351.
-            flag = flag + 1;
+            testUsed = true;
             return this.cursor < this.a.length;
         }
 
@@ -46,15 +45,30 @@ public class Issue1351 {
     }
 
     @CommandLine.Command
-    class TestCommand {
+    class TestCommandWithoutCompletion {
         @CommandLine.Option(names = "-o", completionCandidates = MyIterable.class,
                 description = "Candidates: A, B, C")
         String option;
     }
 
+    @CommandLine.Command
+    class TestCommandWithCompletion{
+        @CommandLine.Option(names = "-o", completionCandidates = MyIterable.class,
+                description = "Candidates: ${COMPLETION-CANDIDATES}")
+        String option;
+    }
+
     @Test
-    public void testIssue1351() {
-        CommandLine.usage(new TestCommand(), System.out);
-        assertEquals(0, flag);
+    public void testCompletionCandidatesUnused() {
+        testUsed = false;
+        CommandLine.usage(new TestCommandWithoutCompletion(), System.out);
+        assertEquals(false, testUsed);
+    }
+
+    @Test
+    public void testCompletionCandidatesUsed(){
+        testUsed = false;
+        CommandLine.usage(new TestCommandWithCompletion(), System.out);
+        assertEquals(true, testUsed);
     }
 }

--- a/src/test/java/picocli/Issue1351.java
+++ b/src/test/java/picocli/Issue1351.java
@@ -1,0 +1,60 @@
+package picocli;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static org.junit.Assert.assertEquals;
+
+public class Issue1351 {
+    static int flag = 0;
+
+    static class MyIterator implements Iterator<String> {
+        private int cursor;
+        private final String[] a;
+
+        MyIterator(String[] a) {
+            this.a = a;
+        }
+
+        @Override
+        public boolean hasNext() {
+            // Do something in the iterator, maybe talking to a server as was mentioned in issue 1351.
+            flag = flag + 1;
+            return this.cursor < this.a.length;
+        }
+
+        @Override
+        public String next() {
+            int i = this.cursor;
+            if (i >= this.a.length) {
+                throw new NoSuchElementException();
+            } else {
+                this.cursor = i + 1;
+                return this.a[i];
+            }
+        }
+    }
+
+    static class MyIterable implements Iterable<String> {
+        @Override
+        public Iterator<String> iterator() {
+            return new MyIterator(new String[]{"A", "B", "C"});
+        }
+    }
+
+    @CommandLine.Command
+    class TestCommand {
+        @CommandLine.Option(names = "-o", completionCandidates = MyIterable.class,
+                description = "Candidates: A, B, C")
+        String option;
+    }
+
+    @Test
+    public void testIssue1351() {
+        CommandLine.usage(new TestCommand(), System.out);
+        assertEquals(0, flag);
+    }
+}


### PR DESCRIPTION
Hello, I'm with @sustc11810424 and @Lanninger08 to fix issue #1351.

If we've understood it right, we just need to avoid iterating through `completionCandidates` unnecessarily by first checking any existence of `${COMPLETION-CANDIDATES}`.

A very simple solution with a test case is presented in the PR.