### PR TITLE
Update Jline2 README.md to add some recommended workaround about not ANSI compatible terminal

### DIFF
--- a/picocli-shell-jline2/README.md
+++ b/picocli-shell-jline2/README.md
@@ -71,7 +71,7 @@ public class Example {
      * Top-level command that just prints help.
      */
     @Command(name = "", description = "Example interactive shell with completion",
-            footer = {"", "Press Ctrl-D to exit."},
+            footer = {"", "Press Ctrl-C to exit."},
             subcommands = {MyCommand.class, ClearScreen.class, ReadInteractive.class})
     static class CliCommands implements Runnable {
         final ConsoleReader reader;

--- a/picocli-shell-jline2/README.md
+++ b/picocli-shell-jline2/README.md
@@ -155,6 +155,16 @@ public class Example {
     }
     
     public static void main(String[] args) {
+
+        // JLine 2 does not detect some terminal as not ANSI compatible (e.g  Eclipse Console)
+        // See : https://github.com/jline/jline2/issues/185
+        // This is an optional workaround which allow to use picocli heuristic instead :
+        if (!Help.Ansi.AUTO.enabled() && //
+                Configuration.getString(TerminalFactory.JLINE_TERMINAL, TerminalFactory.AUTO).toLowerCase()
+                        .equals(TerminalFactory.AUTO)) {
+            TerminalFactory.configure(Type.NONE);
+        }
+
         try {
             ConsoleReader reader = new ConsoleReader();
             IFactory factory = new CustomFactory(new InteractiveParameterConsumer(reader));


### PR DESCRIPTION
See #1397 for more details.


**Note that 2nd commit should maybe not integrated** but on my side Ctrl-D do nothing and only Ctrl-C is able to stop the application. If this is an issue on my side please just integrate the first commit. 

**Completely out of topic** but I cloned the repo and do nothing special and I already have some repo modification ? (maybe a gitIgnore issue ?)
See : 
![Capture d’écran de 2021-07-30 17-15-30](https://user-images.githubusercontent.com/840294/127674334-d41a9835-bfa7-4644-9f65-0a6739986244.png)
