### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ jdk:
 - openjdk-ea
 
 matrix:
+  fast_finish: true
   exclude:
   - os: macos
     jdk: openjdk8
@@ -49,3 +50,7 @@ after_success:
     if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
     fi
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

According to the official document [Fast Finishing](https://docs.travis-ci.com/user/build-matrix/#fast-finishing), if some rows in the build matrix are allowed to fail, we can add fast_finish: true to the .travis.yml to get faster feedbacks.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
