### PR TITLE
[#1388] Fix subcommand aliases autocomplete regression

### DIFF
--- a/src/main/java/picocli/AutoComplete.java
+++ b/src/main/java/picocli/AutoComplete.java
@@ -560,7 +560,7 @@ public class AutoComplete {
             int count = functionCalls.size();
             CommandSpec spec = descriptor.commandLine.getCommandSpec();
             String full = spec.qualifiedName(" ");
-            String withoutTopLevelCommand = full.substring(spec.root().name().length() + 1);
+            String withoutTopLevelCommand = full.substring(spec.root().name().length() + 1).replace(spec.name(), descriptor.commandName);
 
             functionCalls.add(format("  if CompWordsContainsArray \"${cmds%2$d[@]}\"; then %1$s; return $?; fi\n", descriptor.functionName, count));
             buff.append(      format("  local cmds%2$d=(%1$s)\n", withoutTopLevelCommand, count));

--- a/src/main/java/picocli/AutoComplete.java
+++ b/src/main/java/picocli/AutoComplete.java
@@ -560,7 +560,8 @@ public class AutoComplete {
             int count = functionCalls.size();
             CommandSpec spec = descriptor.commandLine.getCommandSpec();
             String full = spec.qualifiedName(" ");
-            String withoutTopLevelCommand = full.substring(spec.root().name().length() + 1).replace(spec.name(), descriptor.commandName);
+            String withoutTopLevelCommand = full.substring(spec.root().name().length() + 1,
+                    full.length() - spec.name().length()) + descriptor.commandName;
 
             functionCalls.add(format("  if CompWordsContainsArray \"${cmds%2$d[@]}\"; then %1$s; return $?; fi\n", descriptor.functionName, count));
             buff.append(      format("  local cmds%2$d=(%1$s)\n", withoutTopLevelCommand, count));

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -6412,7 +6412,7 @@ public class CommandLine {
              */
             public CommandSpec addSubcommand(String name, CommandLine subCommandLine) {
                 CommandSpec subSpec = subCommandLine.getCommandSpec();
-                String actualName = validateSubcommandName(name, subSpec);
+                String actualName = interpolator.interpolateCommandName(validateSubcommandName(name, subSpec));
                 Tracer t = new Tracer();
                 if (t.isDebug()) {t.debug("Adding subcommand '%s' to '%s'%n", actualName, this.qualifiedName());}
                 String previousName = commands.getCaseSensitiveKey(actualName);
@@ -6422,7 +6422,7 @@ public class CommandLine {
                 subSpec.parent(this);
                 for (String alias : subSpec.aliases()) {
                     if (t.isDebug()) {t.debug("Adding alias '%s' for '%s'%n", (parent == null ? "" : parent.qualifiedName() + " ") + alias, this.qualifiedName());}
-                    previous = commands.put(alias, subCommandLine);
+                    previous = commands.put(interpolator.interpolate(alias), subCommandLine);
                     if (previous != null && previous != subCommandLine) { throw new DuplicateNameException("Alias '" + alias + "' for subcommand '" + actualName + "' is already used by another subcommand of '" + this.name() + "'"); }
                 }
                 subSpec.initCommandHierarchyWithResourceBundle(resourceBundleBaseName(), resourceBundle());

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -6412,7 +6412,7 @@ public class CommandLine {
              */
             public CommandSpec addSubcommand(String name, CommandLine subCommandLine) {
                 CommandSpec subSpec = subCommandLine.getCommandSpec();
-                String actualName = interpolator.interpolateCommandName(validateSubcommandName(name, subSpec));
+                String actualName = validateSubcommandName(interpolator.interpolateCommandName(name), subSpec);
                 Tracer t = new Tracer();
                 if (t.isDebug()) {t.debug("Adding subcommand '%s' to '%s'%n", actualName, this.qualifiedName());}
                 String previousName = commands.getCaseSensitiveKey(actualName);


### PR DESCRIPTION
This seems to fix #1388 regression, and I have added a new test for the issue.

However, this cause #1352 `testIssue1352_SubcommandNameResourceBundle` to fail, which seemed to be caused by `descriptor.commandName` is `${project.cli.command}`, and it's from `commandLine.getSubcommands().entrySet().?.getKey()`, indicating there might be some issue in resource bundle propagation for subcommands.

@remkop any thoughts?