### PR TITLE
Updated CommandSpec.remove(ArgSpec arg) #1434

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -6728,6 +6728,7 @@ public class CommandLine {
                 if (positionalParameters.remove(arg)) {
                     removed++;
                 }
+                args.remove(arg);
                 if (removed == 0) {
                     throw new NoSuchElementException(String.valueOf(arg));
                 }

--- a/src/test/java/picocli/ModelCommandSpecTest.java
+++ b/src/test/java/picocli/ModelCommandSpecTest.java
@@ -1388,6 +1388,7 @@ public class ModelCommandSpecTest {
         spec.remove(old);
         spec.add(newOpenOption);
 
+        assertFalse(spec.args().contains(old));
         String expectAfter = String.format("" +
                 "Usage: <main class>%n");
         assertEquals(expectAfter, cmd.getUsageMessage(Ansi.OFF));
@@ -1410,6 +1411,7 @@ public class ModelCommandSpecTest {
         assertEquals(CommandLine.Range.valueOf("1"), second.index());
 
         spec.remove(second);
+        assertFalse(spec.args().contains(second));
         assertEquals(1, spec.positionalParameters().size());
         assertSame(first, spec.positionalParameters().get(0));
     }


### PR DESCRIPTION
Updated CommandSpec.remove(ArgSpec arg) method to remove the arg from args (List<ArgSpec>) and test case corresponding to same.
Ref: #1434 