### PR TITLE
Fix incorrect autocomplete if file name contains space

### DIFF
--- a/src/main/java/picocli/AutoComplete.java
+++ b/src/main/java/picocli/AutoComplete.java
@@ -288,7 +288,7 @@ public class AutoComplete {
         final String commandName;
         final CommandLine commandLine;
         final CommandLine parent;
-        
+
         CommandDescriptor(String functionName, String commandName, CommandLine commandLine, CommandLine parent) {
             this.functionName = functionName;
             this.commandName = commandName;
@@ -714,6 +714,7 @@ public class AutoComplete {
                 buff.append(format("%s      positionals=$( compgen -W \"$%s_pos_param_args\" -- \"%s\" )\n", indent, paramName, currWord));
             } else if (type.equals(File.class) || "java.nio.file.Path".equals(type.getName())) {
                 buff.append(format("%s    %s (( currIndex >= %d && currIndex <= %d )); then\n", indent, ifOrElif, min, max));
+                buff.append(format("%s      local IFS=$'\\n'\n", indent));
                 buff.append(format("%s      compopt -o filenames\n", indent));
                 buff.append(format("%s      positionals=$( compgen -f -- \"%s\" ) # files\n", indent, currWord));
             } else if (type.equals(InetAddress.class)) {
@@ -758,6 +759,7 @@ public class AutoComplete {
                 buff.append(format("%s      ;;\n", indent));
             } else if (type.equals(File.class) || "java.nio.file.Path".equals(type.getName())) {
                 buff.append(format("%s    %s)\n", indent, concat("|", option.names()))); // "    -f|--file)\n"
+                buff.append(format("%s      local IFS=$'\\n'\n", indent));
                 buff.append(format("%s      compopt -o filenames\n", indent));
                 buff.append(format("%s      COMPREPLY=( $( compgen -f -- \"%s\" ) ) # files\n", indent, currWord));
                 buff.append(format("%s      return $?\n", indent));

--- a/src/test/java/picocli/AutoCompleteTest.java
+++ b/src/test/java/picocli/AutoCompleteTest.java
@@ -779,6 +779,7 @@ public class AutoCompleteTest {
                 "      return\n" +
                 "      ;;\n" +
                 "    -o|--completionScript)\n" +
+                "      local IFS=$'\\n'\n" +
                 "      compopt -o filenames\n" +
                 "      COMPREPLY=( $( compgen -f -- \"${curr_word}\" ) ) # files\n" +
                 "      return $?\n" +

--- a/src/test/resources/picocompletion-demo-help_completion.bash
+++ b/src/test/resources/picocompletion-demo-help_completion.bash
@@ -201,6 +201,7 @@ function _picocli_picocompletion-demo-help_sub2() {
       return
       ;;
     --directory|-d)
+      local IFS=$'\n'
       compopt -o filenames
       COMPREPLY=( $( compgen -f -- "${curr_word}" ) ) # files
       return $?
@@ -322,6 +323,7 @@ function _picocli_picocompletion-demo-help_sub2_subsub3() {
     if (( currIndex >= 0 && currIndex <= 0 )); then
       positionals=$( compgen -W "$cands_pos_param_args" -- "${curr_word}" )
     elif (( currIndex >= 1 && currIndex <= 2 )); then
+      local IFS=$'\n'
       compopt -o filenames
       positionals=$( compgen -f -- "${curr_word}" ) # files
     elif (( currIndex >= 3 && currIndex <= 2147483647 )); then

--- a/src/test/resources/picocompletion-demo_completion.bash
+++ b/src/test/resources/picocompletion-demo_completion.bash
@@ -199,6 +199,7 @@ function _picocli_picocompletion-demo_sub2() {
       return
       ;;
     --directory|-d)
+      local IFS=$'\n'
       compopt -o filenames
       COMPREPLY=( $( compgen -f -- "${curr_word}" ) ) # files
       return $?
@@ -303,6 +304,7 @@ function _picocli_picocompletion-demo_sub2_subsub3() {
     if (( currIndex >= 0 && currIndex <= 0 )); then
       positionals=$( compgen -W "$cands_pos_param_args" -- "${curr_word}" )
     elif (( currIndex >= 1 && currIndex <= 2 )); then
+      local IFS=$'\n'
       compopt -o filenames
       positionals=$( compgen -f -- "${curr_word}" ) # files
     elif (( currIndex >= 3 && currIndex <= 2147483647 )); then


### PR DESCRIPTION
By setting the bash separator to `\n`, `COMPREPLY` now contains file names with spaces without splitting them, and can autocomplete correctly.

![Screenshot1](https://user-images.githubusercontent.com/7200314/142657918-52d029b9-ea3a-4462-8b75-856d4f074b6b.png)

After some preliminary testing, only files with line feed `\n` in their name cannot be autocompleted correctly, but `ls` seem to behave the same, so looks good to me.

![Screenshot2](https://user-images.githubusercontent.com/7200314/142659675-3aa71a50-f92f-453b-9e77-ef05a7e29abe.png)

This pull request will close #1458.