### PR TITLE
Typo in annotation target-type error message

### DIFF
--- a/picocli-codegen/src/main/java/picocli/codegen/annotation/processing/AbstractCommandSpecProcessor.java
+++ b/picocli-codegen/src/main/java/picocli/codegen/annotation/processing/AbstractCommandSpecProcessor.java
@@ -556,7 +556,7 @@ public abstract class AbstractCommandSpecProcessor extends AbstractProcessor {
         } else if (element.getKind() == ElementKind.METHOD) {
             return new TypedMember((ExecutableElement) element, AbstractCommandSpecProcessor.this);
         }
-        error(element, "Cannot only process %s annotations on fields, " +
+        error(element, "Can only process %s annotations on fields, " +
                 "methods and method parameters, not on %s", annotation, element.getKind());
         return null;
     }


### PR DESCRIPTION
An annotation target-type error message has a typo that says "Cannot only process" when it should say "Can only process".