### PR TITLE
Remove execution and extension characters in the generated autocomplete script

### DIFF
--- a/src/main/java/picocli/AutoComplete.java
+++ b/src/main/java/picocli/AutoComplete.java
@@ -422,6 +422,13 @@ public class AutoComplete {
             "# default Bash completions and the Readline default filename completions are performed.\n" +
             "complete -F _complete_%1$s -o default %1$s %1$s.sh %1$s.bash\n";
 
+    private static String sanitizeScriptName(String scriptName) {
+        return scriptName
+                .replaceAll("\\.sh", "")
+                .replaceAll("\\.bash", "")
+                .replaceAll("\\.\\/", "");
+    }
+
     /**
      * Generates source code for an autocompletion bash script for the specified picocli-based application,
      * and writes this script to the specified {@code out} file, and optionally writes an invocation script
@@ -464,6 +471,7 @@ public class AutoComplete {
     public static String bash(String scriptName, CommandLine commandLine) {
         if (scriptName == null)  { throw new NullPointerException("scriptName"); }
         if (commandLine == null) { throw new NullPointerException("commandLine"); }
+        scriptName = sanitizeScriptName(scriptName);
         StringBuilder result = new StringBuilder();
         result.append(format(SCRIPT_HEADER, scriptName, CommandLine.VERSION));
 

--- a/src/test/java/picocli/AutoCompleteTest.java
+++ b/src/test/java/picocli/AutoCompleteTest.java
@@ -1256,6 +1256,18 @@ public class AutoCompleteTest {
     }
 
     @Test
+    public void testBashifyWithExtras() {
+        CommandSpec cmd = CommandSpec.create().addOption(
+                OptionSpec.builder("-x")
+                        .type(String.class)
+                        .paramLabel("_A\tB C")
+                        .completionCandidates(Arrays.asList("1")).build());
+        String actual = AutoComplete.bash("./bashify.sh", new CommandLine(cmd));
+        String expected = format(loadTextFromClasspath("/bashify_completion.bash"), CommandLine.VERSION);
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void testBooleanArgFilter() {
         @Command(name = "booltest")
         class App {


### PR DESCRIPTION
First of all, thanks for the amazing project and all the effort in it @remkop !
This is a follow up from an issue experienced in the Keycloak project:
https://github.com/keycloak/keycloak/pull/8875

Sorry for directly opening a PR instead of an Issue, but I do believe that this change is more self-explanatory in code 🙂 

Rationale:
- `./` breaks the autocomplete script on ZSH
- `.bash` and `.sh` autocompletion extensions are always automatically generated

Sanitizing the internally used `scriptName` sounds like a first step in the right direction, wdyt?