### PR TITLE
Improved AbstractCommandSpecProcessor#isSubcommand(ExecutableElement, RoundEnvironment)

### DIFF
--- a/picocli-codegen/src/main/java/picocli/codegen/annotation/processing/AbstractCommandSpecProcessor.java
+++ b/picocli-codegen/src/main/java/picocli/codegen/annotation/processing/AbstractCommandSpecProcessor.java
@@ -300,10 +300,8 @@ public abstract class AbstractCommandSpecProcessor extends AbstractProcessor {
 
     private boolean isSubcommand(ExecutableElement method, RoundEnvironment roundEnv) {
         Element typeElement = method.getEnclosingElement();
-        if (typeElement.getAnnotation(Command.class) != null && typeElement.getAnnotation(Command.class).addMethodSubcommands()) {
-            return true;
-        }
-        if (typeElement.getAnnotation(Command.class) == null) {
+        Command cmd = typeElement.getAnnotation(Command.class);
+        if (cmd == null) {
             Set<Element> elements = new HashSet<Element>(typeElement.getEnclosedElements());
 
             // The class is a Command if it has any fields or methods annotated with the below:
@@ -314,7 +312,7 @@ public abstract class AbstractCommandSpecProcessor extends AbstractProcessor {
                     || roundEnv.getElementsAnnotatedWith(Unmatched.class).removeAll(elements)
                     || roundEnv.getElementsAnnotatedWith(Spec.class).removeAll(elements);
         }
-        return false;
+        return cmd.addMethodSubcommands();
     }
 
     private Stack<TypeElement> buildTypeHierarchy(TypeElement typeElement) {


### PR DESCRIPTION
Improved AbstractCommandSpecProcessor#isSubcommand(ExecutableElement, RoundEnvironment):

Simplified
Improved performance
Fixed possible correctness bug if RoundEnvironment#getElementsAnnotatedWith(Class) ever returns an unmodifiable Set