### PR TITLE
Improved DefaultFactory#create(Class<T>)

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -5505,12 +5505,10 @@ public class CommandLine {
                     return cls.cast(new LinkedHashMap<Object, Object>());
                 }
             }
+            Constructor<T> constructor = cls.getDeclaredConstructor();
             try {
-                @SuppressWarnings("deprecation") // Class.newInstance is deprecated in Java 9
-                T result = cls.newInstance();
-                return result;
-            } catch (Exception ex) {
-                Constructor<T> constructor = cls.getDeclaredConstructor();
+                return constructor.newInstance();
+            } catch (IllegalAccessException ex) {
                 constructor.setAccessible(true);
                 return constructor.newInstance();
             }

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -5505,12 +5505,19 @@ public class CommandLine {
                     return cls.cast(new LinkedHashMap<Object, Object>());
                 }
             }
-            Constructor<T> constructor = cls.getDeclaredConstructor();
             try {
-                return constructor.newInstance();
-            } catch (IllegalAccessException ex) {
-                constructor.setAccessible(true);
-                return constructor.newInstance();
+                @SuppressWarnings("deprecation") // Class.newInstance is deprecated in Java 9
+                T result = cls.newInstance();
+                return result;
+            } catch (Exception ex) {
+                // TODO log the error at debug level
+                Constructor<T> constructor = cls.getDeclaredConstructor();
+                try {
+                    return constructor.newInstance();
+                } catch (IllegalAccessException iaex) {
+                    constructor.setAccessible(true);
+                    return constructor.newInstance();
+                }
             }
         }
         private static ITypeConverter<?>[] createConverter(IFactory factory, Class<? extends ITypeConverter<?>>[] classes) {

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -32,7 +32,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.ByteOrder;
 import java.nio.charset.Charset;
-import java.nio.charset.UnsupportedCharsetException;
 import java.text.BreakIterator;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -5484,25 +5483,27 @@ public class CommandLine {
                 Callable<?> callable = Callable.class.cast(cls.getConstructor(Object.class, Object.class).newInstance(null, null));
                 try { return (T) callable.call(); }
                 catch (Exception ex) { throw new InitializationException("Error in Groovy closure: " + ex); }
-
             }
-            if (cls.isInterface() && Collection.class.isAssignableFrom(cls)) {
-                if (List.class.isAssignableFrom(cls)) {
-                    return cls.cast(new ArrayList<Object>());
-                } else if (SortedSet.class.isAssignableFrom(cls)) {
-                    return cls.cast(new TreeSet<Object>());
-                } else if (Set.class.isAssignableFrom(cls)) {
-                    return cls.cast(new LinkedHashSet<Object>());
-                } else if (Queue.class.isAssignableFrom(cls)) {
-                    return cls.cast(new LinkedList<Object>()); // ArrayDeque is only available since 1.6
+            if (cls.isInterface()) {
+                if (Collection.class.isAssignableFrom(cls)) {
+                    if (List.class.isAssignableFrom(cls)) {
+                        return cls.cast(new ArrayList<Object>());
+                    } else if (SortedSet.class.isAssignableFrom(cls)) {
+                        return cls.cast(new TreeSet<Object>());
+                    } else if (Set.class.isAssignableFrom(cls)) {
+                        return cls.cast(new LinkedHashSet<Object>());
+                    } else if (Queue.class.isAssignableFrom(cls)) {
+                        return cls.cast(new LinkedList<Object>()); // ArrayDeque is only available since 1.6
+                    } else {
+                        return cls.cast(new ArrayList<Object>());
+                    }
                 }
-                return cls.cast(new ArrayList<Object>());
-            }
-            if (Map.class.isAssignableFrom(cls)) {
-                try { // if it is an implementation class, instantiate it
-                    return cls.cast(cls.getDeclaredConstructor().newInstance());
-                } catch (Exception ignored) { }
-                return cls.cast(new LinkedHashMap<Object, Object>());
+                if (SortedMap.class.isAssignableFrom(cls)) {
+                    return cls.cast(new TreeMap<Object, Object>());
+                }
+                if (Map.class.isAssignableFrom(cls)) {
+                    return cls.cast(new LinkedHashMap<Object, Object>());
+                }
             }
             try {
                 @SuppressWarnings("deprecation") // Class.newInstance is deprecated in Java 9


### PR DESCRIPTION
Improved `DefaultFactory#create(Class<T>)`:

- Only handle `cls` argument being a `Map` or subtype differently than normal if `cls` is an interface
- Create `TreeMap` if `cls` argument is `SortedMap` or sub-interface
- Simplified normal instantiation:
  - no longer call deprecated method
  - only try `setAccessible(true)` if it might make a difference