### PR TITLE
Allow aliases of a CommandSpec that is already a subcommand to be properly & consistently modified.

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -7090,18 +7090,18 @@ public class CommandLine {
              * @return this CommandSpec for method chaining
              * @since 3.1 */
             public CommandSpec aliases(String... aliases) {
-                Set<String> existingAliasSet = this.aliases;
+                Set<String> previousAliasSet = this.aliases;
                 this.aliases = new LinkedHashSet<String>(Arrays.asList(aliases == null ? new String[0] : aliases));
                 if (parent != null) {
                     //remove & add aliases
-                    Set<String> newAliasSet = new LinkedHashSet<String>(this.aliases);
-                    newAliasSet.removeAll(existingAliasSet);
+                    Set<String> addedAliasSet = new LinkedHashSet<String>(this.aliases);
+                    addedAliasSet.removeAll(previousAliasSet);
                     Tracer t = new Tracer();
-                    for (String alias : newAliasSet) {
+                    for (String alias : addedAliasSet) {
                         parent.addAlias(alias, name, commandLine, t);
                     }
-                    existingAliasSet.removeAll(this.aliases);
-                    for (String alias : existingAliasSet) {
+                    previousAliasSet.removeAll(this.aliases);
+                    for (String alias : previousAliasSet) {
                         parent.removeAlias(alias, commandLine, t);
                     }
                 }

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -6428,9 +6428,7 @@ public class CommandLine {
                 if (subSpec.name == null) { subSpec.name(actualName); }
                 subSpec.parent(this);
                 for (String alias : subSpec.aliases()) {
-                    if (t.isDebug()) {t.debug("Adding alias '%s' for '%s'%n", (parent == null ? "" : parent.qualifiedName() + " ") + alias, this.qualifiedName());}
-                    previous = commands.put(interpolator.interpolate(alias), subCommandLine);
-                    if (previous != null && previous != subCommandLine) { throw new DuplicateNameException("Alias '" + alias + "' for subcommand '" + actualName + "' is already used by another subcommand of '" + this.name() + "'"); }
+                    addAlias(alias, actualName, subCommandLine, t);
                 }
                 subSpec.initCommandHierarchyWithResourceBundle(resourceBundleBaseName(), resourceBundle());
                 if (scopeType() == ScopeType.INHERIT) {
@@ -6450,6 +6448,17 @@ public class CommandLine {
                     }
                 }
                 return this;
+            }
+            private void addAlias(String alias, String name, CommandLine subCommandLine, Tracer t) {
+                if (t.isDebug()) {t.debug("Adding alias '%s' for '%s'%n", (parent == null ? "" : parent.qualifiedName() + " ") + alias, qualifiedName());}
+                CommandLine previous = commands.put(interpolator.interpolate(alias), subCommandLine);
+                if (previous != null && previous != subCommandLine) {
+                    throw new DuplicateNameException("Alias '" + alias + "' for subcommand '" + name + "' is already used by another subcommand of '" + name() + "'");
+                }
+            }
+            private void removeAlias(String alias, CommandLine subCommandLine, Tracer t) {
+                if (t.isDebug()) {t.debug("Removing alias '%s' for '%s'%n", (parent == null ? "" : parent.qualifiedName() + " ") + alias, qualifiedName());}
+                commands.remove(interpolator.interpolate(alias));
             }
             private void inheritAttributesFrom(CommandSpec root) {
                 inherited = true;
@@ -7081,7 +7090,21 @@ public class CommandLine {
              * @return this CommandSpec for method chaining
              * @since 3.1 */
             public CommandSpec aliases(String... aliases) {
+                Set<String> existingAliasSet = this.aliases;
                 this.aliases = new LinkedHashSet<String>(Arrays.asList(aliases == null ? new String[0] : aliases));
+                if (parent != null) {
+                    //remove & add aliases
+                    Set<String> newAliasSet = new LinkedHashSet<String>(this.aliases);
+                    newAliasSet.removeAll(existingAliasSet);
+                    Tracer t = new Tracer();
+                    for (String alias : newAliasSet) {
+                        parent.addAlias(alias, name, commandLine, t);
+                    }
+                    existingAliasSet.removeAll(this.aliases);
+                    for (String alias : existingAliasSet) {
+                        parent.removeAlias(alias, commandLine, t);
+                    }
+                }
                 return this;
             }
 

--- a/src/test/java/picocli/Issue1528.java
+++ b/src/test/java/picocli/Issue1528.java
@@ -1,0 +1,74 @@
+package picocli;
+
+import java.util.concurrent.Callable;
+import org.junit.Test;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class Issue1528 {
+
+    @Command(name = "main", subcommands = SubCommand.class)
+    static class MainCommand implements Callable<Integer> {
+        @Override
+        public Integer call() throws Exception {
+            return null;
+        }
+    }
+
+    @Command(name = "sub")
+    static class SubCommand implements Callable<Integer> {
+        @Override
+        public Integer call() throws Exception {
+            return null;
+        }
+    }
+
+    @Test
+    public void testSubCommandAliasModification() {
+        CommandLine cl = new CommandLine(new MainCommand());
+        CommandSpec cs = cl.getSubcommands().get("sub").getCommandSpec();
+
+        assertEquals(0, cs.aliases().length);
+        assertEquals(0, cl.execute("sub"));
+        assertNotEquals(0, cl.execute("alias1"));
+
+        cs.aliases("alias1");
+        assertEquals(1, cs.aliases().length);
+        assertEquals("alias1", cs.aliases()[0]);
+        assertEquals(0, cl.execute("sub"));
+        assertEquals(0, cl.execute("alias1"));
+
+        cs.aliases("alias1", "alias2");
+        assertEquals(2, cs.aliases().length);
+        assertEquals("alias1", cs.aliases()[0]);
+        assertEquals("alias2", cs.aliases()[1]);
+        assertEquals(0, cl.execute("sub"));
+        assertEquals(0, cl.execute("alias1"));
+        assertEquals(0, cl.execute("alias2"));
+
+        cs.aliases("alias2");
+        assertEquals(1, cs.aliases().length);
+        assertEquals("alias2", cs.aliases()[0]);
+        assertEquals(0, cl.execute("sub"));
+        assertNotEquals(0, cl.execute("alias1"));
+        assertEquals(0, cl.execute("alias2"));
+
+        cs.aliases("alias3");
+        assertEquals(1, cs.aliases().length);
+        assertEquals("alias3", cs.aliases()[0]);
+        assertEquals(0, cl.execute("sub"));
+        assertNotEquals(0, cl.execute("alias1"));
+        assertNotEquals(0, cl.execute("alias2"));
+        assertEquals(0, cl.execute("alias3"));
+
+        cs.aliases(new String[0]);
+        assertEquals(0, cs.aliases().length);
+        assertEquals(0, cl.execute("sub"));
+        assertNotEquals(0, cl.execute("alias1"));
+        assertNotEquals(0, cl.execute("alias2"));
+        assertNotEquals(0, cl.execute("alias3"));
+    }
+}


### PR DESCRIPTION
Allow aliases of a CommandSpec that is already a subcommand to be properly & consistently modified.

Resolves #1528

Doesn't yet contain tests.  Wanted feedback before I implement tests.

Will add tests and whatever else is requested once the current state of the PR has been reviewed.