### PR TITLE
1615: Fix bug in getCJKAdjustedLength() that double counts supplement…

### DIFF
--- a/src/test/java/picocli/CJKLengthTest.java
+++ b/src/test/java/picocli/CJKLengthTest.java
@@ -1,0 +1,39 @@
+
+package picocli;
+
+import static org.junit.Assert.assertEquals;
+import static picocli.CommandLine.Help.Ansi;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.ProvideSystemProperty;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.rules.TestRule;
+
+public class CJKLengthTest {
+
+    // allows tests to set any kind of properties they like, without having to individually roll them back
+    @Rule
+    public final TestRule restoreSystemProperties = new RestoreSystemProperties();
+
+    @Rule
+    public final ProvideSystemProperty ansiOFF = new ProvideSystemProperty("picocli.ansi", "false");
+
+    @Test
+    public void testCJKLengths() {
+      testLength("abc", 3);
+      // some double width Hiragana characters
+      testLength("平仮名", 6);
+
+      // a supplementary code point character (has a high and low code point values)
+      testLength("𝑓", 1);
+    }
+
+    private void testLength(String of, int expectedLength) {
+      Ansi.Text text = Ansi.OFF.text(of);
+      int cjkWidth = text.getCJKAdjustedLength();
+      assertEquals(String.format("Expected '%s' to have width %d but is %d", of, expectedLength, cjkWidth),
+          expectedLength, cjkWidth);
+    }
+
+}


### PR DESCRIPTION
…ary code points

getCJKAdjustedLength calculates the column width of text strings.

But it operates on chars which causes it to double count supplementary code
points. Supplimentary code points have a high and a low code unit(char).

This commit reworks this logic to be based on code points. The code assembles
the code points by hand as String.codePoints() was only added in 1.8 and
picocli has a source level of 1.5

closes #1615