### PR TITLE
User guide, chapter 3.2.3. Forcing Interactive Input: code sample: add Kotlin version

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -689,6 +689,25 @@ public class Main implements Runnable {
 }
 ----
 
+.Kotlin
+[source,kotlin,role="secondary"]
+----
+@Command
+class Main : Runnable {
+    @Option(names = ["--interactive"], description = ["unattended run"], interactive = true)
+    var value: String? = null
+    override fun run() {
+        if (value == null && System.console() != null) {
+            // alternatively, use console::readPassword
+            value = System.console().readLine("Enter value for --interactive: ")
+        }
+        println("You provided value '$value'")
+    }
+}
+
+fun main(args: Array<String>) : Unit = exitProcess(CommandLine(Main()).execute(*args))
+----
+
 === Short (POSIX) Options
 Picocli supports http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html#tag_12_02[POSIX clustered short options]:
 one or more single-character options without option-arguments, followed by at most one option with an option-argument, can be grouped behind one '-' delimiter.


### PR DESCRIPTION
While running the sample code, I realized that there is a minor glitch here: if there is no description given for the interactive option, there are opening and closing braces which make no sense without the description string:

```
Enter value for --interactive (): 
```

Would be nice if these braces were supressed if no description string is given.

