### PR TITLE
Doc improvements

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1070,7 +1070,7 @@ command line with lots of options or with long arguments for options.
 
 Starting from v2.1.0, picocli supports "argument files" or "@-files".
 Argument files are files that themselves contain arguments to the command.
-When picocli encounters an argument beginning with the character `@',
+When picocli encounters an argument beginning with the character `@`,
 it expands the contents of that file into the argument list.
 
 An argument file can include options and positional parameters in any combination.
@@ -1114,23 +1114,28 @@ The above will be expanded to the contents of the file:
 java MyCommand ABC -option=123 "X Y Z"
 ----
 
-CAUTION: Handling of UTF-8 encoded argument files is tricky on Windows OS.
-Either use `-DFile.encoding=UTF8` as VM argument or set the environment variable `JAVA_TOOL_OPTIONS`.
+[CAUTION]
+====
+Handling of UTF-8 encoded argument files is tricky on Windows OS with Java up to version 17.
+Either use `-Dfile.encoding=UTF-8` as VM argument or set the environment variable `JAVA_TOOL_OPTIONS`.
 So both command calls given below will work on a Windows command line:
 [source,cmd]
 ----
-java -DFile.encoding=UTF8 MyCommand ABC -option=123 "X Y Z"
+java -Dfile.encoding=UTF-8 MyCommand @/home/foo/args
 ----
 [source,cmd]
 ----
-SET JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
-java MyCommand ABC -option=123 "X Y Z"
+SET JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8
+java MyCommand @/home/foo/args
 ----
-
+====
+CAUTION: In Java 18 the default encoding was changed from a system dependent value to
+always be UTF-8. If you require the old behavior, you need to
+set the `file.encoding` system property to the value `COMPAT`.
 
 @-file expansion can be switched off by calling `CommandLine::setExpandAtFiles` with `false`.
-If turned on, you can still pass a real parameter with an initial '@' character by escaping it
-with an additional '@' symbol, e.g. '@@somearg' will become '@somearg' and not be subject to expansion.
+If turned on, you can still pass a real parameter with an initial `@` character by escaping it
+with an additional `@` symbol, e.g. `@@somearg` will become `@somearg` and not be subject to expansion.
 
 This feature is similar to the 'Command Line Argument File' processing supported by gcc, javadoc and javac.
 The documentation for these tools has more details.
@@ -1184,7 +1189,7 @@ Most of the built-in types work with Java 5, but picocli also has some default c
 * `java.nio.ByteOrder` (from picocli 2.2, for the Strings `"BIG_ENDIAN"` or `"LITTLE_ENDIAN"`)
 * `java.util.Currency` (from picocli 2.2, for the ISO 4217 code of the currency)
 * `java.net.NetworkInterface` (from picocli 2.2, for the InetAddress or name of the network interface)
-* `java.util.TimeZoneConverter` (from picocli 2.2, for the ID for a TimeZone)
+* `java.util.TimeZone` (from picocli 2.2, for the ID for a TimeZone)
 
 Converters loaded using reflection:
 
@@ -1602,7 +1607,7 @@ See the <<Split Regex>> section for details.
 
 
 ==== Maps
-Picocli 1.0 introduced support for `Map` fields similar to Java's system properties `-Dkey=value` or Gradle's project properties `-Pmyprop=myvalue`.
+Picocli 1.0 introduced support for `Map` fields similar to Java's system properties `-Dkey=value` or Gradle properties `-P myprop=myvalue`.
 
 `Map` fields may have any type for their key and value
 as long as a <<Strongly Typed Everything,converter>> is registered for both the key and the value type.
@@ -1652,18 +1657,18 @@ Map options may be specified multiple times with different key-value pairs. (See
 If the annotated field is `null`, picocli will instantiate it when the option or positional parameter is matched.
 If the `Map` type is not a concrete class, picocli will instantiate a `LinkedHashMap` to preserve the input ordering.
 
-NOTE: On the command line, the key and the value must be separated by a `=` character.
+NOTE: On the command line, the key and the value must be separated by an `=` character.
 
 Map options and positional parameters can be defined with a `split` regular expression to allow end users to specify multiple values in a single parameter.
 See the <<Split Regex>> section for details.
 
 ==== Key-only map parameters
 By default, picocli expects Map options and positional parameters to look like `key=value`,
-that is, the option parameter or positional parameter is expected to have a key part and a value part, separated by a `=` character.
+that is, the option parameter or positional parameter is expected to have a key part and a value part, separated by an `=` character.
 If this is not the case, picocli shows a user-facing error message: `Value for ... should be in KEY=VALUE format but was ...`.
 
 From picocli 4.6, applications can specify a `mapFallbackValue` to allow end users to specify only the key part.
-The specified `mapFallbackValue` is put into the map when end users to specify only a key.
+The specified `mapFallbackValue` is put into the map when end users do specify only a key.
 The value type can be <<Optional<T>, wrapped in a `java.util.Optional`>>.
 For example:
 
@@ -3726,9 +3731,9 @@ class MyMapper : IExitCodeExceptionMapper {
 }
 ----
 
-When the end user specified invalid input, the `execute` method prints an error message followed by the usage help message of the command, and returns an exit code. This can be <<Invalid User Input,customized>> by configuring a `IParameterExceptionHandler`.
+When the end user specified invalid input, the `execute` method prints an error message followed by the usage help message of the command, and returns an exit code. This can be <<Invalid User Input,customized>> by configuring an `IParameterExceptionHandler`.
 
-If the business logic of the command throws an exception, the `execute` method prints the stack trace of the exception and returns an exit code. This can be customized by configuring a `IExecutionExceptionHandler`.
+If the business logic of the command throws an exception, the `execute` method prints the stack trace of the exception and returns an exit code. This can be customized by configuring an `IExecutionExceptionHandler`.
 
 === Usage Help Exit Code Section
 By default, the usage help message does not include exit code information.
@@ -3754,7 +3759,7 @@ CAUTION: The above methods are not applicable with (and ignored by) other entry 
 
 === Migration
 
-Older versions of picocli supported `run`, `call`, `invoke` and `parseWithHandlers` convenience methods that were similar to `execute` but had limited support for parser configuration and and limited support for exit codes.
+Older versions of picocli supported `run`, `call`, `invoke` and `parseWithHandlers` convenience methods that were similar to `execute` but had limited support for parser configuration and limited support for exit codes.
 These methods are deprecated from picocli 4.0.
 The sections below show some common usages and how the same can be achieved with the `execute` API.
 
@@ -5195,7 +5200,7 @@ This allows you to control:
 
 By default, a set of https://picocli.info/apidocs-all/info.picocli/picocli/CommandLine.RegexTransformer.html#createDefault--[regular expressions] is used to control the above.
 Use `CommandLine::setNegatableOptionTransformer` to replace the https://picocli.info/apidocs-all/info.picocli/picocli/CommandLine.INegatableOptionTransformer[`INegatableOptionTransformer`] with a custom version.
-See the javadoc for details.
+See the JavaDoc for details.
 
 === Custom Parameter Processing
 
@@ -5203,7 +5208,7 @@ As of version 4.6, picocli offers two different parser plugins for custom parame
 
 ==== `IParameterConsumer` Parser Plugin
 
-Options or positional parameters can be assigned a `IParameterConsumer` that implements
+Options or positional parameters can be assigned an `IParameterConsumer` that implements
 custom logic to process the parameters for this option or this position.
 When an option or positional parameter with a custom `IParameterConsumer`
 is matched on the command line, picocli's internal parser is temporarily suspended,
@@ -5277,7 +5282,7 @@ CAUTION: Make sure any nested classes are `static`, or picocli will not be able 
 
 Introduced in picocli 4.6, the `IParameterPreprocessor` is also a parser plugin, similar to `IParameterConsumer`, but more flexible.
 
-Options, positional parameters and commands can be assigned a `IParameterPreprocessor` that implements custom logic to preprocess the parameters for this option, position or command.
+Options, positional parameters and commands can be assigned an `IParameterPreprocessor` that implements custom logic to preprocess the parameters for this option, position or command.
 When an option, positional parameter or command with a custom `IParameterPreprocessor` is matched on the command line, picocli's internal parser is temporarily suspended, and this custom logic is invoked.
 
 This custom logic may completely replace picocli's internal parsing for this option, positional parameter or command, or augment it by doing some preprocessing before picocli's internal parsing is resumed for this option, positional parameter or command.
@@ -5395,8 +5400,8 @@ With this preprocessor in place the user can now specify his editor of choice (e
 | | *`IParameterPreprocessor`* | *`IParameterConsumer`*
 | *Summary* | Either augment (return `false`) or replace (return `true`) picocli parsing logic for the matched element. | Replaces picocli parsing logic for the matched element.
 | *Scope* | Commands as well as options and positional parameters. | Options and positional parameters only.
-| *Read parser state* | Yes, information may received via the `info` Map | No
-| *Modify parser state* | Yes, via modifying the `info` Map | No
+| *Read parser state* | Yes, information may be received via the `info` map | No
+| *Modify parser state* | Yes, via modifying the `info` map | No
 |===
 
 
@@ -5884,7 +5889,7 @@ of any command that uses this version provider.
 
 This is one way to create a version provider that can be reused across multiple commands.
 
-==== Injecting `CommandSpec` Into a `IVersionProvider`
+==== Injecting `CommandSpec` Into an `IVersionProvider`
 
 As of picocli 4.2.0, `IVersionProvider` implementations can have `@Spec`-annotated fields. If such a field
 exists, picocli will inject the `CommandSpec` of the command that uses this version provider.
@@ -6157,7 +6162,7 @@ Usage: myapp [-hV] [-o=<outputFolder>]
   -V, --version                 Print version information and exit.
 ----
 
-The minimum value that can be specified for `longOptionsMaxWidth` is 20, the maximum value is the <<Usage Width,usage width>> minus `20`.
+The minimum value that can be specified for `longOptionsMaxWidth` is 20, the maximum value is the <<Usage Width,usage width>> minus 20.
 
 
 === Usage Width
@@ -6166,7 +6171,7 @@ Commands defined with `@Command(usageHelpWidth = NUMBER)` in the annotations wil
 
 Picocli 3.0 also introduced programmatic API for this via the `CommandLine::setUsageHelpWidth` and `UsageMessageSpec::width` methods.
 
-End users can use system property `picocli.usage.width` to specify a custom width that overrides the programmatically set value.
+End users can use the system property `picocli.usage.width` to specify a custom width that overrides the programmatically set value.
 
 The minimum width that can be configured is 55 characters.
 
@@ -6175,7 +6180,7 @@ The minimum width that can be configured is 55 characters.
 As of picocli 4.0, commands defined with `@Command(usageHelpAutoWidth = true)` will try to adjust the usage message help layout to the terminal width.
 There is also programmatic API to control this via the `CommandLine::setUsageHelpAutoWidth` and `UsageMessageSpec::autoWidth` methods.
 
-End users may enable this by setting system property `picocli.usage.width` to `AUTO`, and may disable this by setting this system property to a numeric value.
+End users may enable this by setting the system property `picocli.usage.width` to `AUTO`, and may disable this by setting this system property to a numeric value.
 
 This feature requires Java 7.
 
@@ -6323,7 +6328,7 @@ The `header` will be shown at the top of the usage help message (before the syno
 
 Use the `footer` attribute to specify one or more lines to show below the generated usage help message.
 
-Each element of the attribute String array is displayed on a separate line.
+Each element of the attribute `String` array is displayed on a separate line.
 
 
 === Exit Code List
@@ -6334,8 +6339,7 @@ For example:
 .Java
 [source,java,role="primary"]
 ----
-@Command(mixinStandardHelpOptions = true,
-         exitCodeListHeading = "Exit Codes:%n",
+@Command(exitCodeListHeading = "Exit Codes:%n",
          exitCodeList = {
              " 0:Successful program execution",
              "64:Usage error: user input for the command was incorrect, " +
@@ -6350,8 +6354,7 @@ new CommandLine(new App()).usage(System.out);
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
-@Command(mixinStandardHelpOptions = true,
-         exitCodeListHeading = "Exit Codes:%n",
+@Command(exitCodeListHeading = "Exit Codes:%n",
          exitCodeList = [
              " 0:Successful program execution",
              "64:Usage error: user input for the command was incorrect,"  +
@@ -6381,7 +6384,7 @@ These are converted to the platform-specific line separator when the usage help 
 
 <<Static Version Information,Version help>> may have format specifiers that format additional arguments passed to the `printVersionHelp` method.
 
-See the https://docs.oracle.com/javase/8/docs/api/java/util/Formatter.html[java.util.Formatter javadoc] for details.
+See the https://docs.oracle.com/javase/8/docs/api/java/util/Formatter.html[java.util.Formatter JavaDoc] for details.
 
 IMPORTANT: Note that to show percent `'%'` characters in the usage help message, they need to be escaped with another `%`. For example: `@Parameters(description = "%%-age of the total")` is rendered as `%-age of the total`.
 
@@ -8549,7 +8552,7 @@ private fun handleParseResult(parsed: CommandLine.ParseResult) {
 ----
 
 You may be interested in the <<Executing Commands,execute method>> to reduce error handling and other boilerplate code in your application.
-See also the previous section, <<Executing Subcommands>>.
+See also the section, <<Executing Subcommands>>.
 
 === Nested sub-Subcommands
 
@@ -9038,7 +9041,7 @@ To reduce duplication, picocli supports two ways to reuse such options and attri
 
 === Subclassing
 One way to reuse options and attributes is to extend the class where they are defined.
-Picocli will walk the class hierarchy to check for annotations, so `@Options`, `@Parameters` and `@Command` attributes declared on a superclass are available in all subclasses.
+Picocli will walk the class hierarchy to check for annotations, so `@Option`, `@Parameters` and `@Command` attributes declared on a superclass are available in all subclasses.
 
 Below is an example class, `ReusableOptions`, that defines some usage help attributes and a `--verbose` option that we want to reuse.
 
@@ -10014,7 +10017,7 @@ userName=Specify the user name. The default is ${DEFAULT-VALUE}.
 
 In your localized application, it may be desirable to specify the locale in order to determine the language of message texts and help output.
 One way of controlling the locale is to give `-Duser.language=desiredLocale` as VM argument when running the app.
-A more accessible and user-friendly approach is to to implement a command line parameter (e. g. `--locale`) inside your app which can be used to change the locale.
+A more accessible and user-friendly approach is to implement a command line parameter (e. g. `--locale`) inside your app which can be used to change the locale.
 The latter technique requires a two-phase approach to parsing in your application in order to get a valid load order.
 The minimal example below demonstrates how to implement this two phase approach:
 
@@ -10237,7 +10240,7 @@ The default value may contain other custom variables. For example:
 ${bundle:a:-${env:b:-${sys:c:-X}}}
 ```
 
-The above variable is expanded as follows. First, try to find key `a` in the command's resource bundle. If `a` is not found in the resource bundle, get the value of environment variable `b`. If no environment variable `b` exists, get the value of system property `c`. Finally, no system property `c` exists, the value of the expression becomes `X`.
+The above variable is expanded as follows. First, try to find key `a` in the command's resource bundle. If `a` is not found in the resource bundle, get the value of environment variable `b`. If no environment variable `b` exists, get the value of system property `c`. Finally, if no system property `c` exists, the value of the expression becomes `X`.
 
 === Escaping Variables
 Sometimes you want to show a string like `"${VAR}"` in a description.
@@ -10455,11 +10458,11 @@ class App {
     String y;
 
     // reset to null when option not specified
-    @Option(names = "-x", defaultValue = Option.NULL)
+    @Option(names = "-x", defaultValue = Option.NULL_VALUE)
     void setX(String x) { this.x = x; }
 
     // retains value of previous parseArgs invocation when option not specified
-    @Option(names = "-y")
+    @nption(names = "-y")
     void setY(String y) { this.y = y; }
 }
 ----
@@ -10472,7 +10475,7 @@ class App {
     var y
 
     // reset to null when option not specified
-    @Option(names = ["-x"], defaultValue = Option.NULL)
+    @Option(names = ["-x"], defaultValue = Option.NULL_VALUE)
     fun setX(x: String) { this.x = x }
 
     // retains value of previous parseArgs invocation when option not specified
@@ -10756,7 +10759,7 @@ public interface IFactory {
 }
 ----
 
-If no factory is specified, a default factory is used. The default factory requires that the classes to instantiate have a public no-argument constructor: it instantiates the class by calling first calling `clazz.newInstance()`, and if that fails, `clazz.getDeclaredConstructor().newInstance()`.
+If no factory is specified, a default factory is used. The default factory requires that the classes to instantiate have a public no-argument constructor: it instantiates the class by first calling `clazz.newInstance()`, and if that fails, `clazz.getDeclaredConstructor().newInstance()`.
 
 From version 4.0, picocli delegates all object creation to the factory, including creating `Collection` instances to capture <<Arrays and Collections,multi-value>> `@Option` values.
 Previously, `Collection` objects were instantiated separately without involving the factory.
@@ -10934,7 +10937,7 @@ assertEquals(Arrays.asList(*args), auto.allParameters)
 ====
 Automatic indexes depend on the ability of Java reflection and Java annotation processors to iterate over fields in declaration order in the source code.
 Officially this is not guaranteed by the Java spec.
-In practice this has worked in Oracle JVMs and OpenJDK from Java 6, but there is some risk this may not work in the future or on other JVM's.
+In practice this has worked in Oracle JVMs and OpenJDK from Java 6, but there is some risk this may not work in the future or on other JVMs.
 In general, for single-value positional parameters, using <<Explicit Index,explicit indexes>> is the safer option.
 (Multi-value positional parameters can safely omit the `index` attribute.)
 ====
@@ -11934,7 +11937,7 @@ import io.quarkus.picocli.runtime.annotations.TopCommand;
 import picocli.CommandLine.*;
 
 @TopCommand // <3>
-@Command (subcommands = MailCommand.HeaderCommand.class, requiredOptionMarker = '*')
+@Command(subcommands = MailCommand.HeaderCommand.class, requiredOptionMarker = '*')
 public class MailCommand implements Runnable { // <1>
     private Mail mail = new Mail();
     @Inject Mailer mailer;  // Quarkus mailer
@@ -12074,7 +12077,7 @@ With all required options and parameters specified, a mail is sent successfully.
 .Sending emails in a development and production systems
 ====
 If you are running Quarkus in DEV or TEST mode, mails are not actually sent, but printed on `STDOUT` and collected in a `MockMailbox` bean instead.
-In a production system, to have to set the boolean configuration value `quarkus.mailer.mock` to `true`. Additionally to need to give further configuration values (STMP host name, … inside the file `src/main/resources/application.properties`.
+In a production system, you have to set the boolean configuration value `quarkus.mailer.mock` to `true`. Additionally, you need to give further configuration values (SMTP host name, … inside the file `src/main/resources/application.properties`.
 Please refer to the Quarkus guide https://quarkus.io/guides/mailer[Sending Emails] for details and additional information.
 ====
 
@@ -12200,7 +12203,7 @@ open module com.yourorg.yourapp {
 
 == OSGi Bundle
 
-image:https://www.osgi.org/wp-content/uploads/OSGi-website-header-logo.png[OSGi logo]
+image:https://www.osgi.org/images/logo/osgi.png[OSGi logo]
 
 From 4.0, the picocli JAR is an OSGi bundle with `Bundle-Name: picocli` and other appropriate metadata in the manifest.
 
@@ -12892,6 +12895,9 @@ Use `jlink` with the `--launcher` option to generate launcher scripts for your a
 
 See https://medium.com/azulsystems/using-jlink-to-build-java-runtimes-for-non-modular-applications-9568c5e70ef4[this article] for using jlink for non-modular applications.
 
+Gradle users may like these plugins: https://badass-runtime-plugin.beryx.org/releases/latest/[org.beryx Badass Runtime Plugin]
+and https://badass-jlink-plugin.beryx.org/releases/latest/[org.beryx Badass JLink Plugin].
+
 === jpackage
 jpackage is a packaging tool according to https://openjdk.java.net/jeps/343[JEP 343] which ships with JDK 14.
 JPackage can take the custom light-weight JRE produced by `jlink` and create an installer and a native application launcher.
@@ -12901,8 +12907,6 @@ and the custom light-weight JRE runtime image (including the application modules
 
 For further details, you may read the https://docs.oracle.com/en/java/javase/14/docs/specs/man/jpackage.html[jpackage synopsis] or study the https://docs.oracle.com/en/java/javase/14/jpackage/[Packaging Tool User's Guide].
 This https://www.infoq.com/news/2019/03/jep-343-jpackage/[InfoQ article] may be of interest, too.
-Gradle users may like these plugins: https://badass-runtime-plugin.beryx.org/releases/latest/[org.beryx Badass Runtime Plugin]
-and https://badass-jlink-plugin.beryx.org/releases/latest/[org.beryx Badass JLink Plugin].
 
 === jbang
 
@@ -13171,10 +13175,10 @@ object MyApp {
 
 In order to get you started quickly, you may have a look at the https://github.com/remkop/picocli/tree/main/picocli-examples/src/main/scala/picocli/examples/scala[Scala examples] folder of the picocli code repository.
 
-== API Javadoc
-Picocli API Javadoc can be found link:apidocs-all/[here].
+== API JavaDoc
+Picocli API JavaDoc can be found link:apidocs-all/[here].
 
-See also: https://remkop.github.io/picocli/apidocs-all[latest version], https://picocli.info/man/3.x/apidocs[picocli 3.x javadoc].
+See also: https://picocli.info/man/3.x/apidocs[Picocli 3.x JavaDoc].
 
 
 == GitHub Project
@@ -13215,9 +13219,7 @@ implementation 'info.picocli:picocli:4.7.0-SNAPSHOT'
 .Gradle (Kotlin)
 [source,kotlin,role="secondary"]
 ----
-dependencies {
-    implementation("info.picocli:picocli:4.7.0-SNAPSHOT")
-}
+implementation("info.picocli:picocli:4.7.0-SNAPSHOT")
 ----
 
 .Maven
@@ -13271,5 +13273,5 @@ libraryDependencies += "info.picocli" % "picocli" % "4.7.0-SNAPSHOT"
 === Source
 
 By using picocli in source form, you can avoid having an external dependency on picocli.
-Picocli has only one source file: link:https://github.com/remkop/picocli/blob/v4.6.3-SNAPSHOT/src/main/java/picocli/CommandLine.java[CommandLine.java].
+Picocli has only one source file: link:https://github.com/remkop/picocli/blob/v4.7.0-SNAPSHOT/src/main/java/picocli/CommandLine.java[CommandLine.java].
 This facilitates including picocli in your project: simply copy and paste the code of this file into a file called `CommandLine.java`, add it to your project, and enjoy!

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -14997,7 +14997,7 @@ public class CommandLine {
         static class ISO8601TimeConverter implements ITypeConverter<Object> {
             // Implementation note: use reflection so that picocli only requires the java.base module in Java 9.
             private final Constructor<?> constructor;
-            ISO8601TimeConverter(Constructor<?> constructor) throws NoSuchMethodException {
+            ISO8601TimeConverter(Constructor<?> constructor) {
                 this.constructor = Assert.notNull(constructor, "time class constructor");
             }
             public Object convert(String value) {


### PR DESCRIPTION
A couple of improvements and mainly fixes to the manual.

I didn't find whether you replace versions manually or somehow automated.
In the last paragraph there is a link to `CommandLine.java` that still pointed to `4.6.3-SNAPSHOT` while the remaining document points to `4.7.0-SNAPSHOT`, so however you do the replacement, that spot was missed.