### PR TITLE
[https://github.com/remkop/picocli/issues/1696] Fix asciidoc output for nested ArgGroups

### DIFF
--- a/picocli-codegen/src/main/java/picocli/codegen/docgen/manpage/ManPageGenerator.java
+++ b/picocli-codegen/src/main/java/picocli/codegen/docgen/manpage/ManPageGenerator.java
@@ -500,7 +500,7 @@ public class ManPageGenerator implements Callable<Integer> {
         IParameterRenderer parameterRenderer = spec.commandLine().getHelp().createDefaultParameterRenderer();
 
         List<ArgGroupSpec> groups = optionListGroups(spec);
-        for (ArgGroupSpec group : groups) { options.removeAll(group.options()); }
+        for (ArgGroupSpec group : groups) { options.removeAll(group.allOptionsNested()); }
 
         if (options.isEmpty() && !spec.usageMessage().showEndOfOptionsDelimiterInUsageHelp()) {
             pw.printf("// tag::picocli-generated-man-section-options[]%n");
@@ -534,12 +534,12 @@ public class ManPageGenerator implements Callable<Integer> {
             String heading = makeHeading(group.heading(), "Options Group");
             pw.printf("== %s%n", COLOR_SCHEME.text(heading));
 
-            for (PositionalParamSpec positional : group.positionalParameters()) {
+            for (PositionalParamSpec positional : group.allPositionalParametersNested()) {
                 if (!positional.hidden()) {
                     writePositional(pw, positional, parameterRenderer, paramLabelRenderer);
                 }
             }
-            List<OptionSpec> groupOptions = new ArrayList<OptionSpec>(group.options());
+            List<OptionSpec> groupOptions = new ArrayList<OptionSpec>(group.allOptionsNested());
             if (optionSort != null) {
                 Collections.sort(groupOptions, optionSort);
             }


### PR DESCRIPTION
As described in https://github.com/remkop/picocli/issues/1696, this fix utilizes the `ArgGroupSpec#allOptionsNested()` and `ArgGroupSpec#allPositionalParametersNested()` to list options under the proper group in the asciidoc output.

Note that this fix may cause an option to be shown multiple times in the output when nesting multiple ArgGroups with headings. For example, if an ArgGroup with heading `Top` contains another ArgGroup with heading `Nested`, then any options defined in the `Nested` group will be listed under both `Top` and `Nested` groups in the asciidoc output. Not sure whether this is a valid/common use case though, and functionally both `ArgGroups` contain that option (directly or indirectly), so it's not even really wrong.

For reference, following is a sample command class and corresponding asciidoc output when using this fix.

Test class:
```
import picocli.CommandLine.ArgGroup;
import picocli.CommandLine.Command;
import picocli.CommandLine.Option;
import picocli.CommandLine.Parameters;
import picocli.CommandLine.Help.Visibility;

@Command(name="test")
public class TestCommand {
	@Option(names={"option0"}, required = false, defaultValue = "option0", showDefaultValue = Visibility.ALWAYS) 
	private String option1;
	@Parameters(index="0") 
	private String param0;
	@ArgGroup(exclusive = false, multiplicity = "1", heading = "Top")
	private ArgGroup1 argGroup1;
	 
	
	static class ArgGroup1 {
		@Option(names={"option1"}, required = false, defaultValue = "option1", showDefaultValue = Visibility.ALWAYS) 
		private String option1;
		@Parameters(index="1") 
		private String param1;
		@ArgGroup(exclusive = false, multiplicity = "1", heading = "Nested")
		private ArgGroup2 argGroup2;
		@ArgGroup(exclusive = false, multiplicity = "1")
		private ArgGroup3 argGroup3;
	}
	
	public static class ArgGroup2 {
		@Option(names={"option2"}, required = false, defaultValue = "option2", showDefaultValue = Visibility.ALWAYS) 
		private String option2;
		@Parameters(index="2") 
		private String param2;
	}
	
	public static class ArgGroup3 {
		@Option(names={"option3"}, required = false, defaultValue = "option3", showDefaultValue = Visibility.ALWAYS) 
		private String option3;
		@Parameters(index="3") 
		private String param3;
	}
}
```

Asciidoc output:
```
// tag::picocli-generated-full-manpage[]
// tag::picocli-generated-man-section-header[]
:doctype: manpage
:revnumber: 
:manmanual: Test Manual
:mansource: 
:man-linkstyle: pass:[blue R < >]
= test(1)

// end::picocli-generated-man-section-header[]

// tag::picocli-generated-man-section-name[]
== Name

test - 

// end::picocli-generated-man-section-name[]

// tag::picocli-generated-man-section-synopsis[]
== Synopsis

*test* [*option0*=_<option1>_] ([*option1*=_<option1>_] _<param1>_ ([*option2*=_<option2>_]
     _<param2>_) ([*option3*=_<option3>_] _<param3>_)) _<param0>_

// end::picocli-generated-man-section-synopsis[]

// tag::picocli-generated-man-section-description[]
== Description



// end::picocli-generated-man-section-description[]

// tag::picocli-generated-man-section-options[]
== Options

*option0*=_<option1>_::
    Default: option0

== Nested

_<param2>_::
  

*option2*=_<option2>_::
    Default: option2

== Top

_<param1>_::
  

_<param2>_::
  

_<param3>_::
  

*option1*=_<option1>_::
    Default: option1

*option2*=_<option2>_::
    Default: option2

*option3*=_<option3>_::
    Default: option3

// end::picocli-generated-man-section-options[]

// tag::picocli-generated-man-section-arguments[]
== Arguments

_<param0>_::
  

_<param3>_::
  

// end::picocli-generated-man-section-arguments[]

// tag::picocli-generated-man-section-commands[]
// end::picocli-generated-man-section-commands[]

// tag::picocli-generated-man-section-exit-status[]
// end::picocli-generated-man-section-exit-status[]

// tag::picocli-generated-man-section-footer[]
// end::picocli-generated-man-section-footer[]

// end::picocli-generated-full-manpage[]
```