### PR TITLE
[Issue 1708] Ignore invalid values in setUsageHelpLongOptionsMaxWidth

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -7820,17 +7820,15 @@ public class CommandLine {
             /**
              * Sets the maximum usage help long options column max width to the specified value.
              * This value controls the maximum width of the long options column: any positional parameter labels or long options that are longer than the specified value will overflow into the description column, and cause the description to be displayed on the next line.
-             * @param newValue the new maximum usage help long options column max width. Must be 20 or greater.
+             * @param newValue the new maximum usage help long options column max width. Must be 20 or greater, otherwise the new value will be ignored.
              * @return this {@code UsageMessageSpec} for method chaining
-             * @throws IllegalArgumentException if the specified long options column max is less than 20
              * @since 4.2 */
             public UsageMessageSpec longOptionsMaxWidth(int newValue) {
-                if (newValue < DEFAULT_USAGE_LONG_OPTIONS_WIDTH) {
-                    throw new InitializationException("Invalid usage long options max width " + newValue + ". Minimum value is " + DEFAULT_USAGE_LONG_OPTIONS_WIDTH);
-                } else if (newValue > width() - DEFAULT_USAGE_LONG_OPTIONS_WIDTH) {
-                    throw new InitializationException("Invalid usage long options max width " + newValue + ". Value must not exceed width(" + width() + ") - " + DEFAULT_USAGE_LONG_OPTIONS_WIDTH);
+                if (newValue >= DEFAULT_USAGE_LONG_OPTIONS_WIDTH && newValue <= width() - DEFAULT_USAGE_LONG_OPTIONS_WIDTH) {
+                    longOptionsMaxWidth = newValue;
                 }
-                longOptionsMaxWidth = newValue; return this;
+
+                return this;
             }
 
             private int getSysPropertyWidthOrDefault(int defaultWidth, boolean detectTerminalSize) {

--- a/src/test/java/picocli/HelpTest.java
+++ b/src/test/java/picocli/HelpTest.java
@@ -4387,12 +4387,13 @@ public class HelpTest {
 
     @Test
     public void testUsageMessageSpec_LongOptionsColumnLengthMinimum_Minimum20() {
-        try {
-            CommandSpec.create().usageMessage().longOptionsMaxWidth(19);
-            fail("Expected exception");
-        } catch (InitializationException ok) {
-            assertEquals("Invalid usage long options max width 19. Minimum value is 20", ok.getMessage());
-        }
+        CommandLine cmd = new CommandLine(CommandSpec.create());
+        cmd.setUsageHelpLongOptionsMaxWidth(20);
+
+        CommandLine returnValue = cmd.setUsageHelpLongOptionsMaxWidth(19);
+
+        assertEquals(20, cmd.getUsageHelpLongOptionsMaxWidth());
+        assertEquals(20, cmd.getCommandSpec().usageMessage().longOptionsMaxWidth());
     }
 
     @Test
@@ -4400,12 +4401,9 @@ public class HelpTest {
         UsageMessageSpec spec = CommandSpec.create().usageMessage();
         spec.longOptionsMaxWidth(spec.width() - 20);
         assertEquals(60, spec.longOptionsMaxWidth());
-        try {
-            spec.longOptionsMaxWidth(61);
-            fail("Expected exception");
-        } catch (InitializationException ok) {
-            assertEquals("Invalid usage long options max width 61. Value must not exceed width(80) - 20", ok.getMessage());
-        }
+
+        spec.longOptionsMaxWidth(61);
+        assertEquals(60, spec.longOptionsMaxWidth());
     }
 
     @Test


### PR DESCRIPTION
This is a fix proposal for https://github.com/remkop/picocli/issues/1708. 

The idea is to avoid exception when the screen is too small and just let setUsageHelpLongOptionsMaxWidth set the newValue when valid.