### PR TITLE
[Issue 1713] Support optional booleans in annotation processor

### DIFF
--- a/picocli-annotation-processing-tests/src/test/java/picocli/annotation/processing/tests/Issue1713Test.java
+++ b/picocli-annotation-processing-tests/src/test/java/picocli/annotation/processing/tests/Issue1713Test.java
@@ -1,0 +1,26 @@
+package picocli.annotation.processing.tests;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import org.junit.Test;
+
+import javax.annotation.processing.Processor;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+
+public class Issue1713Test
+{
+    //@Ignore("https://github.com/remkop/picocli/issues/1713")
+    @Test
+    public void testIssue1713() {
+        Processor processor = new AnnotatedCommandSourceGeneratorProcessor();
+        Compilation compilation =
+                javac()
+                        .withProcessors(processor)
+                        .compile(JavaFileObjects.forResource(
+                                "picocli/issue1713/Command.java"));
+
+        assertThat(compilation).succeeded();
+    }
+}

--- a/picocli-annotation-processing-tests/src/test/resources/picocli/issue1713/Command.java
+++ b/picocli-annotation-processing-tests/src/test/resources/picocli/issue1713/Command.java
@@ -1,0 +1,21 @@
+package picocli.issue1713;
+
+import java.util.Optional;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Spec;
+
+@Command(name = "Command",
+    description = "Command description")
+class Command1 {
+
+    @Spec
+    CommandSpec spec;
+
+    @CommandLine.Option(names = "--progress",
+        description = "A negatable optional boolean should be allowed",
+        negatable = true)
+    Optional<Boolean> progress;
+}

--- a/picocli-codegen/src/main/java/picocli/codegen/annotation/processing/CompileTimeTypeInfo.java
+++ b/picocli-codegen/src/main/java/picocli/codegen/annotation/processing/CompileTimeTypeInfo.java
@@ -150,7 +150,7 @@ class CompileTimeTypeInfo implements CommandLine.Model.ITypeInfo {
     }
 
     static boolean isBooleanType(TypeMirror type) {
-        return type.getKind() == TypeKind.BOOLEAN || "java.lang.Boolean".equals(type.toString());
+        return type.getKind() == TypeKind.BOOLEAN || "java.lang.Boolean".equals(type.toString()) || "java.util.Optional<java.lang.Boolean>".equals(type.toString());
     }
 
     @Override


### PR DESCRIPTION
Fixes #1713 