### PR TITLE
[Issue: #1708] Including log info for invalid values scenario

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -7826,8 +7826,9 @@ public class CommandLine {
             public UsageMessageSpec longOptionsMaxWidth(int newValue) {
                 if (newValue >= DEFAULT_USAGE_LONG_OPTIONS_WIDTH && newValue <= width() - DEFAULT_USAGE_LONG_OPTIONS_WIDTH) {
                     longOptionsMaxWidth = newValue;
+                } else {
+                    CommandLine.tracer().info("Invalid usage long options max width %d. Value must not exceed width(%d) - %d", newValue, width(), DEFAULT_USAGE_LONG_OPTIONS_WIDTH);
                 }
-
                 return this;
             }
 

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -7824,10 +7824,12 @@ public class CommandLine {
              * @return this {@code UsageMessageSpec} for method chaining
              * @since 4.2 */
             public UsageMessageSpec longOptionsMaxWidth(int newValue) {
-                if (newValue >= DEFAULT_USAGE_LONG_OPTIONS_WIDTH && newValue <= width() - DEFAULT_USAGE_LONG_OPTIONS_WIDTH) {
-                    longOptionsMaxWidth = newValue;
+                if (newValue < DEFAULT_USAGE_LONG_OPTIONS_WIDTH) {
+                    CommandLine.tracer().info("Invalid usage long options max width %d. Minimum value is %d", newValue,  DEFAULT_USAGE_LONG_OPTIONS_WIDTH);
+                } else if (newValue > width() - DEFAULT_USAGE_LONG_OPTIONS_WIDTH) {
+                    CommandLine.tracer().info("Invalid usage long options max width %d. Value must not exceed width(%d) - %d", newValue , width(), DEFAULT_USAGE_LONG_OPTIONS_WIDTH);
                 } else {
-                    CommandLine.tracer().info("Invalid usage long options max width %d. Value must not exceed width(%d) - %d", newValue, width(), DEFAULT_USAGE_LONG_OPTIONS_WIDTH);
+                    longOptionsMaxWidth = newValue;
                 }
                 return this;
             }

--- a/src/test/java/picocli/HelpTest.java
+++ b/src/test/java/picocli/HelpTest.java
@@ -4396,7 +4396,7 @@ public class HelpTest {
         assertEquals(20, cmd.getUsageHelpLongOptionsMaxWidth());
         assertEquals(20, cmd.getCommandSpec().usageMessage().longOptionsMaxWidth());
 
-        String expected = "Invalid usage long options max width 19. Value must not exceed width(80) - 20";
+        String expected = "Invalid usage long options max width 19. Minimum value is 20";
         assertTrue(systemErrRule.getLog(), systemErrRule.getLog().contains(expected));
     }
 

--- a/src/test/java/picocli/HelpTest.java
+++ b/src/test/java/picocli/HelpTest.java
@@ -4389,11 +4389,15 @@ public class HelpTest {
     public void testUsageMessageSpec_LongOptionsColumnLengthMinimum_Minimum20() {
         CommandLine cmd = new CommandLine(CommandSpec.create());
         cmd.setUsageHelpLongOptionsMaxWidth(20);
+        TestUtil.setTraceLevel(CommandLine.TraceLevel.INFO);
 
         CommandLine returnValue = cmd.setUsageHelpLongOptionsMaxWidth(19);
 
         assertEquals(20, cmd.getUsageHelpLongOptionsMaxWidth());
         assertEquals(20, cmd.getCommandSpec().usageMessage().longOptionsMaxWidth());
+
+        String expected = "Invalid usage long options max width 19. Value must not exceed width(80) - 20";
+        assertTrue(systemErrRule.getLog(), systemErrRule.getLog().contains(expected));
     }
 
     @Test
@@ -4401,9 +4405,13 @@ public class HelpTest {
         UsageMessageSpec spec = CommandSpec.create().usageMessage();
         spec.longOptionsMaxWidth(spec.width() - 20);
         assertEquals(60, spec.longOptionsMaxWidth());
+        TestUtil.setTraceLevel(CommandLine.TraceLevel.INFO);
 
         spec.longOptionsMaxWidth(61);
         assertEquals(60, spec.longOptionsMaxWidth());
+
+        String expected = "Invalid usage long options max width 61. Value must not exceed width(80) - 20";
+        assertTrue(systemErrRule.getLog(), systemErrRule.getLog().contains(expected));
     }
 
     @Test


### PR DESCRIPTION
In this pr it was included some log info for invalid scenarios from this issue: https://github.com/remkop/picocli/issues/1708 