### PR TITLE
Migrate to new Spring Boot auto configuration introduced in spring bo…

### DIFF
--- a/picocli-spring-boot-starter/src/main/java/picocli/spring/boot/autoconfigure/PicocliAutoConfiguration.java
+++ b/picocli-spring-boot-starter/src/main/java/picocli/spring/boot/autoconfigure/PicocliAutoConfiguration.java
@@ -1,10 +1,10 @@
 package picocli.spring.boot.autoconfigure;
 
-import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import picocli.CommandLine;
 import picocli.CommandLine.IFactory;
@@ -13,7 +13,7 @@ import picocli.spring.PicocliSpringFactory;
 /**
  * @author Thibaud Leprêtre
  */
-@AutoConfiguration
+@Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(CommandLine.class)
 public class PicocliAutoConfiguration {
 

--- a/picocli-spring-boot-starter/src/main/java/picocli/spring/boot/autoconfigure/PicocliAutoConfiguration.java
+++ b/picocli-spring-boot-starter/src/main/java/picocli/spring/boot/autoconfigure/PicocliAutoConfiguration.java
@@ -1,10 +1,10 @@
 package picocli.spring.boot.autoconfigure;
 
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import picocli.CommandLine;
 import picocli.CommandLine.IFactory;
@@ -13,7 +13,7 @@ import picocli.spring.PicocliSpringFactory;
 /**
  * @author Thibaud Leprêtre
  */
-@Configuration
+@AutoConfiguration
 @ConditionalOnClass(CommandLine.class)
 public class PicocliAutoConfiguration {
 

--- a/picocli-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/picocli-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=picocli.spring.boot.autoconfigure.PicocliAutoConfiguration

--- a/picocli-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/picocli-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=picocli.spring.boot.autoconfigure.PicocliAutoConfiguration

--- a/picocli-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/picocli-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+picocli.spring.boot.autoconfigure.PicocliAutoConfiguration


### PR DESCRIPTION
…ot 2.7. The existing spring.factories support will be removed in spring boot 3 so this will make sure that the autoconfiguration will still work in when upgrading to spring boot 3.