### PR TITLE
Fixing broken links and typos

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -370,7 +370,7 @@ Artifacts in this release are signed by Remko Popma (6601 E5C0 8DCC BB96).
 * [#1331] Bugfix: Avoid `IllegalArgumentException` when parent has no standard help options and `scope = INHERIT`, while subcommand does have mixed-in standard help options. Thanks to [Andreas Deininger](https://github.com/deining) for raising this.
 * [#1381][#1382] Bugfix: Default value of option in repeated subcommand was not applied correctly. Thanks to [sfeuerhahn](https://github.com/sfeuerhahn) for the pull request.
 * [#1434][#1435] `CommandSpec.remove(arg)` should also remove the arg from the `args` collection in the CommandSpec. Thanks to [kaushalkumar](https://github.com/kaushalkumar) for the pull request.
-* [#1404] Bugfix/Enhancement: Print paramLabel only when it could exist. Thanks to [João Guerra](https://github.com/joca-bt) for the pull reqeust.
+* [#1404] Bugfix/Enhancement: Print paramLabel only when it could exist. Thanks to [João Guerra](https://github.com/joca-bt) for the pull request.
 * [#1320][#1321] Bugfix/Enhancement: Use system properties `sun.stdout.encoding` and `sun.stderr.encoding` when creating the `PrintWriters` returned by  `CommandLine::getOut` and `CommandLine::getErr`. Thanks to [Philippe Charles](https://github.com/charphi) for the investigation and the pull request.
 * [#1431] Bugfix/enhancement: `.gitattributes` should include HTML files to convert CRLF to LF. Thanks to [wenhoujx](https://github.com/wenhoujx) for pointing this out.
 * [#1388][#1430] Bugfix: Fix subcommand aliases autocomplete regression. Thanks to [NewbieOrange](https://github.com/NewbieOrange) for the pull request.
@@ -1066,7 +1066,7 @@ For details see the [New and Noteworthy](#4.4.0-new) section below.
 
 Another important change are parser fixes and improvements: the parser will no longer assign values that match an option name to options that take a parameter, unless the value is in quotes. Also, values that resemble, but not exactly match, option names are now treated more consistently and parser behaviour for such values is configurable.
 
-Also worth hightlighting: from this release, the `ManPageGenerator` tool can be used as a subcommand in your application.
+Also worth highlighting: from this release, the `ManPageGenerator` tool can be used as a subcommand in your application.
 
 This release has many more improvements for customizing the usage help message, JANSI fixes, and other bugfixes and improvements. See the [Fixed Issues](#4.4.0-fixes) list for details.
 
@@ -1911,7 +1911,7 @@ myapp add -x=item1 -w=0.2 \
 ```
 
 In the above command line invocation, the `myapp` top-level command is followed by its subcommand `add`.
-Next, this is followed by another two occurences of `add`, followed by `list` and `send-report`.
+Next, this is followed by another two occurrences of `add`, followed by `list` and `send-report`.
 These are all "sibling" commands, that share the same parent command `myapp`.
 This invocation is valid because `myapp` is marked with `subcommandsRepeatable = true`.
 
@@ -4818,7 +4818,7 @@ No features were deprecated in this release.
 The `picocli.AutoComplete` application no longer calls `System.exit()` unless requested by setting system property `picocli.autocomplete.systemExitOnError` or `picocli.autocomplete.systemExitOnSuccess` to any value other than `false`.
 Applications that rely on the exit codes introduced in picocli 3.9.0 need to set these system properties.
 
-The new support for quoted map keys with embedded '=' characters [#594] may inpact some existing applications.
+The new support for quoted map keys with embedded '=' characters [#594] may impact some existing applications.
 If `CommandLine::setTrimQuotes()` is set to `true`, quotes are now removed from map keys and map values. This did not use to be the case.
 
 For example:
@@ -8403,7 +8403,7 @@ Renamed class `Arity` to `Range` since it is not just used for @Option and @Para
 
 # <a name="0.9.1"></a> 0.9.1 - Bugfix release for public review. API may change.
 
-* [#103] Replace javadoc occurences of ASCII with ANSI.  (doc bug)
+* [#103] Replace javadoc occurrences of ASCII with ANSI.  (doc bug)
 * [#102] Move ColorScheme inside Ansi class  (enhancement question wontfix)
 * [#101] Cosmetics: indent `Default: <value>` by 2 spaces  (enhancement)
 * [#100] Improve error message for DuplicateOptionAnnotationsException  (enhancement)

--- a/docs/announcing-picocli-1.0.adoc
+++ b/docs/announcing-picocli-1.0.adoc
@@ -37,7 +37,7 @@ Including as source is optional. If you prefer to use picocli as a library, that
 == Customizable Usage Help - with ANSI Styles and Colors
 Usage help is the face of a command line application. The generated help message should look great out of the box, but should also be easy to tweak.
 
-Do you want your application's usage help to look http://picocli.info/index.html#_compact_example[compact], or do you prefer a more http://picocli.info/index.html#_expanded_example[spacious] look? A good command line library should let you customize the usage help message to accomodate a variety of styles.
+Do you want your application's usage help to look http://picocli.info/index.html#_compact_example[compact], or do you prefer a more http://picocli.info/index.html#_expanded_example[spacious] look? A good command line library should let you customize the usage help message to accommodate a variety of styles.
 
 This is easily accomplished in picocli with http://picocli.info/index.html#_section_headings[annotations]. Separate annotations exist for sections like description, header and footer. Text can be multi-line and each section has a customizable heading. If the annotations are not sufficient, picocli has a Help http://picocli.info/index.html#_usage_help_api[API] that offers some building blocks for further customizing the help message. This may range from the basic (reordering sections and passing parameters for https://docs.oracle.com/javase/8/docs/api/java/util/Formatter.html#syntax[format specifiers] in the headings or section text) to the more advanced (http://picocli.info/index.html#_custom_layout[custom layouts] for options).
 

--- a/docs/build-great-native-cli-apps-in-java-with-graalvm-and-picocli.adoc
+++ b/docs/build-great-native-cli-apps-in-java-with-graalvm-and-picocli.adoc
@@ -60,7 +60,7 @@ The full set of https://www.graalvm.org/reference-manual/native-image/Limitation
 Two limitations are of particular interest:
 
 * https://www.graalvm.org/reference-manual/native-image/Limitations/#reflection[reflection]
-* https://www.graalvm.org/reference-manual/native-image/Resources/[resources]
+* https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/Resources/[resources]
 
 Basically, to create a self-contained binary, the native image compiler needs to know up-front all the classes of your application, their dependencies, and the resources they use. Reflection and resource bundles often require configuration. We will see an example of this later on.
 
@@ -198,7 +198,7 @@ Next, let’s take a look at turning it into a native executable.
 
 === Reflection Configuration
 
-We mentioned earlier that the native image compiler has some limitations: reflection is supported but https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/[requires configuration].
+We mentioned earlier that the native image compiler has some limitations: reflection is supported but https://www.graalvm.org/22.2/reference-manual/native-image/overview/BuildConfiguration/[requires configuration].
 
 This impacts picocli-based applications: at runtime, picocli uses reflection to discover any `@Command`-annotated subcommands, and the `@Option` and `@Parameters`-annotated command options and positional parameters.
 
@@ -239,7 +239,7 @@ This quickly becomes quite cumbersome for utilities with many options, but fortu
 The `picocli-codegen` module includes an annotation processor that can build a model from the picocli annotations at compile time rather than at runtime.
 
 The annotation processor generates Graal configuration files under `META-INF/native-image/picocli-generated/$project` during compilation, to be included in the application jar.
-This includes configuration files for https://www.graalvm.org/reference-manual/native-image/Reflection/[reflection], https://www.graalvm.org/reference-manual/native-image/Resources/[resources] and https://www.graalvm.org/reference-manual/native-image/DynamicProxy/[dynamic proxies].
+This includes configuration files for https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/Reflection/[reflection], https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/Resources/[resources] and https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/DynamicProxy/[dynamic proxies].
 By embedding these configuration files, your jar is instantly Graal-enabled.
 In most cases no further configuration is needed when generating a native image.
 

--- a/docs/groovy-2.5-clibuilder-renewal-part1.adoc
+++ b/docs/groovy-2.5-clibuilder-renewal-part1.adoc
@@ -275,14 +275,14 @@ The Commons CLI version of CliBuilder, and previous versions of CliBuilder, expo
 If your application uses the `parser` property to set a different Commons CLI parser, consider using the `posix` property instead, or import `groovy.cli.commons.CliBuilder`.
 
 === Different Parser Behavior for `longOption`
-The Commons CLI `DefaultParser` recognizes `longOption` option names prefixed with a single hypen (e.g., `-option`)
+The Commons CLI `DefaultParser` recognizes `longOption` option names prefixed with a single hyphen (e.g., `-option`)
 as well as options prefixed with a double hyphen (e.g., `--option`).
 This is not always obvious since the usage help message only shows the double hyphen prefix for `longOption` option names.
 
 For backwards compatibility, the picocli version of CliBuilder has an `acceptLongOptionsWithSingleHyphen` property:
 set this property to `true` if the parser should recognize long option names with both
 a single hyphen and a double hyphen prefix. The default is `false`,
-so only long option names with a double hypen prefix (`--option`) are recognized.
+so only long option names with a double hyphen prefix (`--option`) are recognized.
 
 == Wait, There's More...
 

--- a/docs/groovy-2.5-clibuilder-renewal.adoc
+++ b/docs/groovy-2.5-clibuilder-renewal.adoc
@@ -521,14 +521,14 @@ The Commons CLI version of CliBuilder, and previous versions of CliBuilder, expo
 If your application uses the `parser` property to set a different Commons CLI parser, consider using the `posix` property instead, or import `groovy.cli.commons.CliBuilder`.
 
 === Different Parser Behavior for `longOption`
-The Commons CLI `DefaultParser` recognizes `longOption` option names prefixed with a single hypen (e.g., `-option`)
+The Commons CLI `DefaultParser` recognizes `longOption` option names prefixed with a single hyphen (e.g., `-option`)
 as well as options prefixed with a double hyphen (e.g., `--option`).
 This is not always obvious since the usage help message only shows the double hyphen prefix for `longOption` option names.
 
 For backwards compatibility, the picocli version of CliBuilder has an `acceptLongOptionsWithSingleHyphen` property:
 set this property to `true` if the parser should recognize long option names with both
 a single hyphen and a double hyphen prefix. The default is `false`,
-so only long option names with a double hypen prefix (`--option`) are recognized.
+so only long option names with a double hyphen prefix (`--option`) are recognized.
 
 == Conclusion
 Groovy 2.5 CliBuilder offers a host of exciting new features. Try it out and let us know what you think!

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -8735,7 +8735,7 @@ myapp add -x=item1 -w=0.2 \
 ----
 
 In the above command line invocation, the `myapp` top-level command is followed by its subcommand `add`.
-Next, this is followed by another two occurences of `add`, followed by `list` and `send-report`.
+Next, this is followed by another two occurrences of `add`, followed by `list` and `send-report`.
 These are all "sibling" commands, that share the same parent command `myapp`.
 This invocation is valid because `myapp` is marked with `subcommandsRepeatable = true`.
 
@@ -10140,7 +10140,7 @@ Hello Sarah!
 Hello Lea!
 ----
 
-In order to control the locale choosen for our output, we have to make use of the command line parameter `--locale`:
+In order to control the locale chosen for our output, we have to make use of the command line parameter `--locale`:
 
 [source,bash]
 ----
@@ -12890,7 +12890,7 @@ See also this https://github.com/remkop/picocli-native-image-demo[demo Gradle pr
 
 A https://skife.org/java/unix/2011/06/20/really_executable_jars.html[really executable JAR]
 is a JAR file that is also a shell script which executes the JAR by running it with `java`.
-It thus functions as an exectuable, is portable across operating systems and architectures,
+It thus functions as an executable, is portable across operating systems and architectures,
 and is still a valid JAR file that can be executed explicitly or otherwise used as a JAR.
 
 The https://github.com/brianm/really-executable-jars-maven-plugin[Really Executable JAR Maven Plugin]

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -302,9 +302,9 @@ The `picocli-codegen` module includes an annotation processor that can build a m
 Enabling this annotation processor in your project is optional, but strongly recommended. Use this if you’re interested in:
 
 * **Compile time error checking**. The annotation processor shows errors for invalid annotations and attributes immediately when you compile, instead of during testing at runtime, resulting in shorter feedback cycles.
-* **<<GraalVM Native Image,GraalVM native images>>**. The annotation processor generates and updates https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/[GraalVM configuration] files under
+* **<<GraalVM Native Image,GraalVM native images>>**. The annotation processor generates and updates https://www.graalvm.org/22.2/reference-manual/native-image/overview/BuildConfiguration/[GraalVM configuration] files under
 `META-INF/native-image/picocli-generated/$project` during compilation, to be included in the application jar.
-This includes configuration files for https://www.graalvm.org/reference-manual/native-image/Reflection/[reflection], https://www.graalvm.org/reference-manual/native-image/Resources/[resources] and https://www.graalvm.org/reference-manual/native-image/DynamicProxy/[dynamic proxies].
+This includes configuration files for https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/Reflection/[reflection], https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/Resources/[resources] and https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/DynamicProxy/[dynamic proxies].
 By embedding these configuration files, your jar is instantly Graal-enabled.
 In most cases no further configuration is needed when generating a native image.
 
@@ -12849,8 +12849,8 @@ ahead-of-time compile Java code to a standalone executable, called a native imag
 The resulting executable includes the application, the libraries, and the JDK and does not require a separate Java VM to be installed.
 The generated native image has faster startup time and lower runtime memory overhead compared to a Java VM.
 
-GraalVM native images have some limitations and require some extra https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/[configuration]
-to be able to use features like https://www.graalvm.org/reference-manual/native-image/Reflection/[reflection], https://www.graalvm.org/reference-manual/native-image/Resources/[resources] (including resource bundles) and https://www.graalvm.org/reference-manual/native-image/DynamicProxy/[dynamic proxies].
+GraalVM native images have some limitations and require some extra https://www.graalvm.org/22.2/reference-manual/native-image/overview/BuildConfiguration/[configuration]
+to be able to use features like https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/Reflection/[reflection], https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/Resources/[resources] (including resource bundles) and https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/DynamicProxy/[dynamic proxies].
 
 ==== How do I Create a Native Image for my Application?
 The `picocli-codegen` module contains an annotation processor that generates the necessary configuration files
@@ -12859,7 +12859,7 @@ to be included in the application jar. The <<Annotation Processor>> section of t
 file.
 
 By embedding these configuration files, your jar is instantly Graal-enabled: the
-https://www.graalvm.org/docs/reference-manual/aot-compilation/#install-native-image[`native-image` tool]
+https://www.graalvm.org/22.2/reference-manual/native-image/#install-native-image[`native-image` tool]
 used to generate the native executable is able to get the configuration from the jar.
 In most cases no further configuration is needed when generating a native image.
 

--- a/docs/picocli-on-graalvm.adoc
+++ b/docs/picocli-on-graalvm.adoc
@@ -72,7 +72,7 @@ The generated `reflect.json` files looks something like this:
 TIP: If necessary, it is possible to exclude classes with system property `picocli.codegen.excludes`, which accepts a comma-separated list of regular expressions of the fully qualified class names that should not be included in the resulting JSON String.
 
 === Compiling a Native Image
-This assumes you have GraalVM installed, with prerequisites. From https://www.graalvm.org/docs/reference-manual/aot-compilation/[the site]:
+This assumes you have GraalVM installed, with prerequisites. From https://www.graalvm.org/22.2/reference-manual/native-image/[the site]:
 
 [quote]
 ____

--- a/gradle/docs.gradle
+++ b/gradle/docs.gradle
@@ -43,7 +43,7 @@ javadoc {
 javadoc.dependsOn(jar)
 javadoc.dependsOn('asciidoctor')
 asciidoctorj {
-    version = '2.5.3'
+    version = '2.5.5'
 }
 asciidoctor {
     sourceDir = file('docs')

--- a/picocli-codegen/README.adoc
+++ b/picocli-codegen/README.adoc
@@ -27,7 +27,7 @@ If a tool does not have an annotation processor wrapper (yet), it can be invoked
 As of picocli version 4.2, this module has three major use cases:
 
 * **Compile time error checking**. The annotation processor shows errors for invalid annotations and attributes immediately when you compile, instead of during testing at runtime, resulting in shorter feedback cycles.
-* **GraalVm native images**. To create a GraalVM native image for a picocli application, https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/[configuration] is needed. The `ReflectionConfigGenerator`, `ResourceConfigGenerator` and `DynamicProxyGenerator` tools can generate `reflect-config.json`, `resource-config.json` and `proxy-config.json` configuration files for https://www.graalvm.org/reference-manual/native-image/Reflection/[reflection], https://www.graalvm.org/reference-manual/native-image/Resources/[resources] and https://www.graalvm.org/reference-manual/native-image/DynamicProxy/[dynamic proxies], respectively.
+* **GraalVm native images**. To create a GraalVM native image for a picocli application, https://www.graalvm.org/22.2/reference-manual/native-image/overview/BuildConfiguration/[configuration] is needed. The `ReflectionConfigGenerator`, `ResourceConfigGenerator` and `DynamicProxyGenerator` tools can generate `reflect-config.json`, `resource-config.json` and `proxy-config.json` configuration files for https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/Reflection/[reflection], https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/Resources/[resources] and https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/DynamicProxy/[dynamic proxies], respectively.
 +
 The annotation processor embeds these three tools and generates the configuration files under `META-INF/native-image/picocli-generated/$project` during compilation, to be included in the application jar.
 By embedding these configuration files, your jar is instantly GraalVM-enabled.
@@ -43,10 +43,10 @@ To build a GraalVM native image for a picocli-based application, configuration f
 The `picocli-codegen` module has tools that generate these configuration files for a picocli-based application.
 The annotation processor in the `picocli-codegen` jar wraps these tools so they are executed automatically during compilation.
 
-The annotation processor generates and updates https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/[GraalVM configuration]
+The annotation processor generates and updates https://www.graalvm.org/22.2/reference-manual/native-image/overview/BuildConfiguration/[GraalVM configuration]
 files under `META-INF/native-image/picocli-generated/$project` during compilation,
 to be included in the application jar.
-This includes configuration files for https://www.graalvm.org/reference-manual/native-image/Reflection/[reflection], https://www.graalvm.org/reference-manual/native-image/Resources/[resources] and https://www.graalvm.org/reference-manual/native-image/DynamicProxy/[dynamic proxies].
+This includes configuration files for https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/Reflection/[reflection], https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/Resources/[resources] and https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/DynamicProxy/[dynamic proxies].
 By embedding these configuration files, your jar is instantly GraalVM-enabled.
 
 In most cases no further configuration is needed when generating a native image.
@@ -285,11 +285,11 @@ This directory (or any of its subdirectories) is searched for files with the nam
 which are then automatically included in the build. Not all of those files must be present.
 When multiple files with the same name are found, all of them are included.
 
-See also the SubstrateVM https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/[configuration documentation].
+See also the SubstrateVM https://www.graalvm.org/22.2/reference-manual/native-image/overview/BuildConfiguration/[configuration documentation].
 
 === ReflectionConfigGenerator
 
-GraalVM has https://www.graalvm.org/reference-manual/native-image/Reflection/[limited support for Java reflection]
+GraalVM has https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/Reflection/[limited support for Java reflection]
 and it needs to know ahead of time the reflectively accessed program elements.
 
 `ReflectionConfigGenerator` generates a JSON String with the program elements that will be accessed reflectively in a picocli-based application, in order to compile this application ahead-of-time into a native executable with GraalVM.
@@ -297,7 +297,7 @@ and it needs to know ahead of time the reflectively accessed program elements.
 The <<Generate Documentation,generated>> manual page for the `ReflectionConfigGenerator` tool https://picocli.info/man/gen-reflect-config.html[is here].
 
 The output of `ReflectionConfigGenerator` is intended to be passed to the `-H:ReflectionConfigurationFiles=/path/to/reflect-config.json` option of the `native-image` GraalVM utility,
-or placed in a `META-INF/native-image/` subdirectory of the JAR. 
+or placed in a `META-INF/native-image/` subdirectory of the JAR.
 
 This allows picocli-based applications to be compiled to a native image.
 
@@ -309,7 +309,7 @@ _Note that the <<Generate GraalVM Configurations with the Annotation Processor,a
 
 The `--output` option can be used to specify the path of the file to write the configuration to.
 When this option is omitted, the output is sent to standard out.
- 
+
 The `ReflectionConfigGenerator` tool accepts any number of fully qualified class names of command classes
 (classes with picocli annotations like `@Command`, `@Option` and `@Parameters`).
 The resulting configuration file will contain entries for the reflected elements of all specified classes.
@@ -397,7 +397,7 @@ assemble.dependsOn generateGraalReflectionConfig
 === ResourceConfigGenerator
 
 The GraalVM native-image builder by default will not integrate any of the
-https://www.graalvm.org/reference-manual/native-image/Resources/[classpath resources] into the image it creates.
+https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/Resources/[classpath resources] into the image it creates.
 
 `ResourceConfigGenerator` generates a JSON String with the resource bundles and other classpath resources
 that should be included in the Substrate VM native image.
@@ -405,7 +405,7 @@ that should be included in the Substrate VM native image.
 The <<Generate Documentation,generated>> manual page for the `ResourceConfigGenerator` tool https://picocli.info/man/gen-resource-config.html[is here].
 
 The output of `ResourceConfigGenerator` is intended to be passed to the `-H:ResourceConfigurationFiles=/path/to/resource-config.json` option of the `native-image` GraalVM utility,
-or placed in a `META-INF/native-image/` subdirectory of the JAR. 
+or placed in a `META-INF/native-image/` subdirectory of the JAR.
 
 This allows picocli-based native image applications to access these resources.
 
@@ -415,7 +415,7 @@ _Note that the <<Generate GraalVM Configurations with the Annotation Processor,a
 
 The `--output` option can be used to specify the path of the file to write the configuration to.
 When this option is omitted, the output is sent to standard out.
- 
+
 The `ResourceConfigGenerator` tool accepts any number of fully qualified class names of command classes
 (classes with picocli annotations like `@Command`, `@Option` and `@Parameters`).
 The resulting configuration file will contain entries for the resource bundles used in any of the specified commands or their subcommands.
@@ -504,8 +504,8 @@ assemble.dependsOn generateGraalResourceConfig
 
 === DynamicProxyConfigGenerator
 
-Substrate VM doesn't provide machinery for generating and interpreting bytecodes at run time. Therefore all dynamic proxy classes 
-https://www.graalvm.org/reference-manual/native-image/DynamicProxy/[need to be generated] at native image build time.
+Substrate VM doesn't provide machinery for generating and interpreting bytecodes at run time. Therefore all dynamic proxy classes
+https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/DynamicProxy/[need to be generated] at native image build time.
 
 `DynamicProxyConfigGenerator` generates a JSON String with the fully qualified interface names for which
 dynamic proxy classes should be generated at native image build time.
@@ -524,7 +524,7 @@ _Note that the <<Generate GraalVM Configurations with the Annotation Processor,a
 
 The `--output` option can be used to specify the path of the file to write the configuration to.
 When this option is omitted, the output is sent to standard out.
- 
+
 The `DynamicProxyConfigGenerator` tool accepts any number of fully qualified class names of command classes
 (classes with picocli annotations like `@Command`, `@Option` and `@Parameters`).
 The resulting configuration file will contain entries for the resource bundles used in any of the specified commands or their subcommands.
@@ -785,7 +785,7 @@ This generates AsciiDoc files with the 'manpage' doctype in `build/generated/doc
 CAUTION: Do this only once, then remove the `--template-dir` option, so that subsequent `ManPageGenerator` invocations will only update the generated manpage AsciiDoc files and will not overwrite the template files.
 
 CAUTION: If the `ManPageGenerator` tool detects an existing template file, it will abort with an error (and exit code 4).
-The existing template will not be overwritten unless the `--force` option is specified. 
+The existing template will not be overwritten unless the `--force` option is specified.
 
 We can now edit the files in `src/docs/man-templates` and tell the `asciidoctor` tool to generate HTML and man page files in troff format from the files in `src/docs/man-templates`.
 

--- a/picocli-codegen/src/main/java/picocli/codegen/aot/graalvm/DynamicProxyConfigGenerator.java
+++ b/picocli-codegen/src/main/java/picocli/codegen/aot/graalvm/DynamicProxyConfigGenerator.java
@@ -22,15 +22,15 @@ import java.util.concurrent.Callable;
  * <p>
  * Substrate VM doesn't provide machinery for generating and interpreting bytecodes at run time.
  * Therefore all dynamic proxy classes
- * <a href="https://www.graalvm.org/reference-manual/native-image/DynamicProxy/">need to be generated</a>
+ * <a href="https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/DynamicProxy/">need to be generated</a>
  * at native image build time.
  * </p><p>
  * The output of {@code DynamicProxyConfigGenerator} is intended to be passed to the {@code -H:DynamicProxyConfigurationFiles=/path/to/proxy-config.json}
- * option of the {@code native-image} <a href="https://www.graalvm.org/docs/reference-manual/aot-compilation/">GraalVM utility</a>.
+ * option of the {@code native-image} <a href="https://www.graalvm.org/22.2/reference-manual/native-image/">GraalVM utility</a>.
  * This allows picocli-based native image applications that use {@code @Command}-annotated interfaces with
  * {@code @Option} and {@code @Parameters}-annotated methods to define options and positional parameters.
  * </p><p>
- * Alternatively, the generated <a href="https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/">configuration</a>
+ * Alternatively, the generated <a href="https://www.graalvm.org/22.2/reference-manual/native-image/overview/BuildConfiguration/">configuration</a>
  * files can be supplied to the {@code native-image} tool by placing them in a
  * {@code META-INF/native-image/} directory on the class path, for example, in a JAR file used in the image build.
  * This directory (or any of its subdirectories) is searched for files with the names {@code jni-config.json},
@@ -47,7 +47,7 @@ public class DynamicProxyConfigGenerator {
             description = {"Generates a JSON file with the interface names to generate dynamic proxy classes for in the native image.",
                     "The generated JSON file can be passed to the `-H:DynamicProxyConfigurationFiles=/path/to/proxy-config.json` " +
                     "option of the `native-image` GraalVM utility.",
-                    "See https://www.graalvm.org/reference-manual/native-image/DynamicProxy/"},
+                    "See https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/DynamicProxy/"},
             exitCodeListHeading = "%nExit Codes (if enabled with `--exit`)%n",
             exitCodeList = {
                     "0:Successful program execution.",
@@ -110,7 +110,7 @@ public class DynamicProxyConfigGenerator {
      *
      * @param specs one or more {@code CommandSpec} objects to inspect for dynamic proxies
      * @param interfaceClasses other (non-{@code @Command}) fully qualified interface names to generate dynamic proxy classes for
-     * @return a JSON String in the <a href="https://www.graalvm.org/reference-manual/native-image/DynamicProxy/#manual-configuration">format</a>
+     * @return a JSON String in the <a href="https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/DynamicProxy/#manual-configuration">format</a>
      *       required by the {@code -H:DynamicProxyConfigurationFiles=/path/to/proxy-config.json} option of the GraalVM {@code native-image} utility.
      */
     public static String generateProxyConfig(CommandSpec[] specs, String[] interfaceClasses) {

--- a/picocli-codegen/src/main/java/picocli/codegen/aot/graalvm/ReflectionConfigGenerator.java
+++ b/picocli-codegen/src/main/java/picocli/codegen/aot/graalvm/ReflectionConfigGenerator.java
@@ -47,14 +47,14 @@ import java.util.concurrent.Callable;
  * reflectively in a picocli-based application, in order to compile this application ahead-of-time into a native
  * executable with GraalVM.
  * <p>
- * GraalVM has <a href="https://www.graalvm.org/reference-manual/native-image/Reflection/">limited support for Java
+ * GraalVM has <a href="https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/Reflection/">limited support for Java
  * reflection</a> and it needs to know ahead of time the reflectively accessed program elements.
  * </p><p>
  * The output of {@code ReflectionConfigGenerator} is intended to be passed to the {@code -H:ReflectionConfigurationFiles=/path/to/reflect-config.json}
- * option of the {@code native-image} <a href="https://www.graalvm.org/docs/reference-manual/aot-compilation/">GraalVM utility</a>.
+ * option of the {@code native-image} <a href="https://www.graalvm.org/22.2/reference-manual/native-image/">GraalVM utility</a>.
  * This allows picocli-based applications to be compiled to a native image.
  * </p><p>
- * Alternatively, the generated <a href="https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/">configuration</a>
+ * Alternatively, the generated <a href="https://www.graalvm.org/22.2/reference-manual/native-image/overview/BuildConfiguration/">configuration</a>
  * files can be supplied to the {@code native-image} tool by placing them in a
  * {@code META-INF/native-image/} directory on the class path, for example, in a JAR file used in the image build.
  * This directory (or any of its subdirectories) is searched for files with the names {@code jni-config.json},
@@ -84,7 +84,7 @@ public class ReflectionConfigGenerator {
                     "accessed reflectively for the specified `@Command` classes.",
                     "The generated JSON file can be passed to the `-H:ReflectionConfigurationFiles=/path/to/reflect-config.json` " +
                     "option of the `native-image` GraalVM utility.",
-                    "See https://www.graalvm.org/reference-manual/native-image/Reflection/"},
+                    "See https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/Reflection/"},
             exitCodeListHeading = "%nExit Codes (if enabled with `--exit`)%n",
             exitCodeList = {
                     "0:Successful program execution.",
@@ -143,7 +143,7 @@ public class ReflectionConfigGenerator {
      * {@code CommandSpec} objects.
      *
      * @param specs one or more {@code CommandSpec} objects to inspect
-     * @return a JSON String in the <a href="https://www.graalvm.org/reference-manual/native-image/Reflection/#manual-configuration">format</a>
+     * @return a JSON String in the <a href="https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/Reflection/#manual-configuration">format</a>
      *       required by the {@code -H:ReflectionConfigurationFiles=/path/to/reflect-config.json} option of the GraalVM {@code native-image} utility.
      * @throws NoSuchFieldException if a problem occurs while processing the specified specs
      * @throws IllegalAccessException if a problem occurs while processing the specified specs

--- a/picocli-codegen/src/main/java/picocli/codegen/aot/graalvm/ResourceConfigGenerator.java
+++ b/picocli-codegen/src/main/java/picocli/codegen/aot/graalvm/ResourceConfigGenerator.java
@@ -20,13 +20,13 @@ import java.util.concurrent.Callable;
  * that should be included in the Substrate VM native image.
  * <p>
  * The GraalVM native-image builder by default will not integrate any of the
- * <a href="https://www.graalvm.org/reference-manual/native-image/Resources/">classpath resources</a> into the image it creates.
+ * <a href="https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/Resources/">classpath resources</a> into the image it creates.
  * </p><p>
  * The output of {@code ResourceConfigGenerator} is intended to be passed to the {@code -H:ResourceConfigurationFiles=/path/to/resource-config.json}
- * option of the {@code native-image} <a href="https://www.graalvm.org/docs/reference-manual/aot-compilation/">GraalVM utility</a>.
+ * option of the {@code native-image} <a href="https://www.graalvm.org/22.2/reference-manual/native-image/">GraalVM utility</a>.
  * This allows picocli-based native image applications to access these resources.
  * </p><p>
- * Alternatively, the generated <a href="https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/">configuration</a>
+ * Alternatively, the generated <a href="https://www.graalvm.org/22.2/reference-manual/native-image/overview/BuildConfiguration/">configuration</a>
  * files can be supplied to the {@code native-image} tool by placing them in a
  * {@code META-INF/native-image/} directory on the class path, for example, in a JAR file used in the image build.
  * This directory (or any of its subdirectories) is searched for files with the names {@code jni-config.json},
@@ -43,7 +43,7 @@ public class ResourceConfigGenerator {
             description = {"Generates a JSON file with the resources and resource bundles to include in the native image.",
                     "The generated JSON file can be passed to the `-H:ResourceConfigurationFiles=/path/to/resource-config.json` " +
                     "option of the `native-image` GraalVM utility.",
-                    "See https://www.graalvm.org/reference-manual/native-image/Resources/"},
+                    "See https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/Resources/"},
             exitCodeListHeading = "%nExit Codes (if enabled with `--exit`)%n",
             exitCodeList = {
                     "0:Successful program execution.",
@@ -111,7 +111,7 @@ public class ResourceConfigGenerator {
      * @param specs one or more {@code CommandSpec} objects to inspect for resource bundles
      * @param bundles base names of additional resource bundles to be included in the image
      * @param resourceRegex one or more Java regular expressions that match resource(s) to be included in the image
-     * @return a JSON String in the <a href="https://www.graalvm.org/reference-manual/native-image/Resources/#resource-bundles-in-native-image">format</a>
+     * @return a JSON String in the <a href="https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/Resources/#resource-bundles-in-native-image">format</a>
      *       required by the {@code -H:ResourceConfigurationFiles=/path/to/resource-config.json} option of the GraalVM {@code native-image} utility.
      */
     public static String generateResourceConfig(CommandSpec[] specs, String[] bundles, String[] resourceRegex) {

--- a/picocli-shell-jline2/README.md
+++ b/picocli-shell-jline2/README.md
@@ -136,7 +136,7 @@ public class Example {
      * Command that optionally reads and password interactively.
      */
     @Command(name = "pwd", mixinStandardHelpOptions = true,
-            description = "Interactivly reads a password", version = "1.0")
+            description = "Interactively reads a password", version = "1.0")
     static class ReadInteractive implements Callable<Void> {
         
         @Option(names = {"-p"}, parameterConsumer = InteractiveParameterConsumer.class)

--- a/src/main/java/overview.html
+++ b/src/main/java/overview.html
@@ -44,7 +44,7 @@
     we recommend also <a href="https://picocli.info/#_annotation_processor">configuring</a>
     the <code>picocli-codegen</code> module as an annotation processor for your project.
     This provides compile-time error checking and
-    generates <a href="https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/">GraalVM
+    generates <a href="https://www.graalvm.org/22.2/reference-manual/native-image/overview/BuildConfiguration/">GraalVM
     configuration files</a> under
     <code>META-INF/native-image/picocli-generated/$project</code> during compilation,
     to be included in the application jar.

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -834,7 +834,7 @@ public class CommandLine {
     }
 
     /** Returns whether abbreviation of subcommands should be allowed when matching subcommands. The default is {@code false}.
-     * @return {@code true} if subcommands can be matched when they are abbrevations of the {@code getCommandName()} value of a registered one, {@code false} otherwise.
+     * @return {@code true} if subcommands can be matched when they are abbreviations of the {@code getCommandName()} value of a registered one, {@code false} otherwise.
      *       For example, if true, for a subcommand with name {@code helpCommand}, inputs like {@code h}, {@code h-c} and {@code hC} are all recognized.
      * @since 4.4 */
     public boolean isAbbreviatedSubcommandsAllowed() {
@@ -860,7 +860,7 @@ public class CommandLine {
     }
 
     /** Returns whether abbreviation of option names should be allowed when matching options. The default is {@code false}.
-     * @return {@code true} if options can be matched when they are abbrevations of the {@code names()} value of a registered one, {@code false} otherwise.
+     * @return {@code true} if options can be matched when they are abbreviations of the {@code names()} value of a registered one, {@code false} otherwise.
      *       For example, if true, for a subcommand with name {@code --helpMe}, inputs like {@code --h}, {@code --h-m} and {@code --hM} are all recognized.
      * @since 4.4 */
     public boolean isAbbreviatedOptionsAllowed() {


### PR DESCRIPTION
This PR
* fixes broken links (docu, javadocs)
* fixes several typos
* updates asciidoctorj to latest version 2.5.5.