### PR TITLE
Fix #1767 - NPE on OptionSpec.getValue() (IScoped)

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -5997,6 +5997,7 @@ public class CommandLine {
         public interface IScope extends IGetter, ISetter {}
         
         /** This interface provides access to an {@link IScope} instance. 
+         * @since 4.7
          */
         public interface IScoped {
             /** Get the {@link IScope} instance.
@@ -9176,14 +9177,15 @@ public class CommandLine {
              * @since 4.3 */
             public ScopeType scopeType() { return scopeType; }
             
-            /** Check whether the {@link #getValue()} method is able to get an actual value from the current {@link #getter()}. */
+            /** Check whether the {@link #getValue()} method is able to get an actual value from the current {@link #getter()}. 
+             * @since 4.7 */
             public boolean isValueGettable() {
                 if (getter instanceof IScoped) {
                     IScoped scoped = (IScoped) getter;
                     IScope scope = scoped.getScope();
+                    if ( scope==null ) { return false; }
                     try {
-                        Object obj = scope.get();
-                        return obj != null;
+                        return scope.get() != null;
                     } catch (Exception e) {
                         return false;
                     }

--- a/src/test/java/picocli/Issue1767.java
+++ b/src/test/java/picocli/Issue1767.java
@@ -1,0 +1,41 @@
+package picocli;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static picocli.CommandLine.ScopeType.INHERIT;
+
+import java.util.concurrent.Callable;
+
+import org.junit.Test;
+
+import picocli.CommandLine.ArgGroup;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.IFactory;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Spec;
+
+public class Issue1767 {
+    @Command(name = "test")
+    static class TestCommand implements Callable<Integer> {
+        @ArgGroup TestArgGroup testArgGroup;
+        @Spec CommandSpec spec;
+        
+        public static class TestArgGroup {
+            @Option(names = "-r")
+            public Integer option1;
+        }
+
+        @Override
+        public Integer call() throws Exception {
+            Integer value = spec.options().get(0).getValue();
+            return value==null ? 0 : value;
+        }
+    }
+
+    @Test
+    public void testIssue1772() {
+        assertEquals(5, new CommandLine(new TestCommand()).execute("-r", "5"));
+        assertEquals(0, new CommandLine(new TestCommand()).execute());
+    }
+}


### PR DESCRIPTION
This PR fixes https://github.com/remkop/picocli/issues/1767, based on the IScoped approach discussed in the issue