### PR TITLE
Change access modifier in READE.md

### DIFF
--- a/picocli-spring-boot-starter/README.md
+++ b/picocli-spring-boot-starter/README.md
@@ -110,10 +110,10 @@ import java.util.concurrent.Callable;
 @Command(name = "mycommand", mixinStandardHelpOptions = true, subcommands = MyCommand.Sub.class)
 public class MyCommand implements Callable<Integer> {
     @Option(names = "-x", description = "optional option")
-    private String x;
+    public String x;;
 
     @Parameters(description = "positional params")
-    private List<String> positionals;
+    public List<String> positionals;
 
     @Override
     public Integer call() {


### PR DESCRIPTION
Access modifier of MyCommand.x and positionals is private in  READE.  But they arer public in the actual sample code. 

https://github.com/remkop/picocli/blob/main/picocli-spring-boot-starter/src/test/java/picocli/spring/boot/autoconfigure/sample/MyCommand.java