### PR TITLE
[#1930] fix 3 failing tests in ManPageGeneratorTest

### DIFF
--- a/picocli-codegen/src/test/java/picocli/codegen/docgen/manpage/ManPageGeneratorTest.java
+++ b/picocli-codegen/src/test/java/picocli/codegen/docgen/manpage/ManPageGeneratorTest.java
@@ -210,7 +210,6 @@ public class ManPageGeneratorTest {
         assertEquals(expected, sw.toString());
     }
 
-    @Ignore("[#1930] - needs test fixes for #1896 changes")
     @Test
     public void testHiddenOptions() throws IOException {
 
@@ -288,7 +287,6 @@ public class ManPageGeneratorTest {
         }
     }
 
-    @Ignore("[#1930] - needs test fixes for #1896 changes")
     @Test
     public void testEndOfOptionsWithoutOptions() throws IOException {
 
@@ -458,7 +456,6 @@ public class ManPageGeneratorTest {
         }
     }
 
-    @Ignore("[#1930] - needs test fixes for #1896 changes")
     @Test
     public void testNamelessCommand() throws IOException {
         File outdir = new File(System.getProperty("java.io.tmpdir"), "manpage" + System.currentTimeMillis());

--- a/picocli-codegen/src/test/resources/manpagegenerator/main_class.adoc
+++ b/picocli-codegen/src/test/resources/manpagegenerator/main_class.adoc
@@ -1,9 +1,9 @@
 // tag::picocli-generated-full-manpage[]
 // tag::picocli-generated-man-section-header[]
 :doctype: manpage
-:revnumber: 
+:revnumber:
 :manmanual: <main class> Manual
-:mansource: 
+:mansource:
 :man-linkstyle: pass:[blue R < >]
 = <main class>(1)
 
@@ -12,7 +12,7 @@
 // tag::picocli-generated-man-section-name[]
 == Name
 
-<main class> - 
+<main class> -
 
 // end::picocli-generated-man-section-name[]
 
@@ -31,13 +31,14 @@
 // end::picocli-generated-man-section-description[]
 
 // tag::picocli-generated-man-section-options[]
+
 // end::picocli-generated-man-section-options[]
 
 // tag::picocli-generated-man-section-arguments[]
 == Arguments
 
 _<file>_::
-  
+
 
 // end::picocli-generated-man-section-arguments[]
 

--- a/picocli-codegen/src/test/resources/testEndOfOptionsWithoutOptions.manpage.adoc
+++ b/picocli-codegen/src/test/resources/testEndOfOptionsWithoutOptions.manpage.adoc
@@ -31,10 +31,6 @@ This app does great things.
 // end::picocli-generated-man-section-description[]
 
 // tag::picocli-generated-man-section-options[]
-== Options
-
-*--*::
-  This option can be used to separate command-line options from the list of positional parameters.
 
 // end::picocli-generated-man-section-options[]
 

--- a/picocli-codegen/src/test/resources/testHiddenOptions.manpage.adoc
+++ b/picocli-codegen/src/test/resources/testHiddenOptions.manpage.adoc
@@ -31,6 +31,7 @@ This app does great things.
 // end::picocli-generated-man-section-description[]
 
 // tag::picocli-generated-man-section-options[]
+
 // end::picocli-generated-man-section-options[]
 
 // tag::picocli-generated-man-section-arguments[]


### PR DESCRIPTION
 Fix 3 failing tests in ManPageGeneratorTest (testEndOfOptionsWithoutOptions, testNamelessCommand, and testHiddenOptions) by updating their respective resource files to account for the additional new lines and white space characters.