### PR TITLE
Bump asciidoctorj to latest version

### DIFF
--- a/gradle/docs.gradle
+++ b/gradle/docs.gradle
@@ -43,7 +43,7 @@ javadoc {
 javadoc.dependsOn(jar)
 javadoc.dependsOn('asciidoctor')
 asciidoctorj {
-    version = '2.5.5'
+    version = '2.5.7'
 }
 asciidoctor {
     sourceDir = file('docs')


### PR DESCRIPTION
This PR bumps dependency `asciidoctorj` to latest released version.