### PR TITLE
Fixed isJansiConsoleInstalled performance issue

### DIFF
--- a/picocli-tests-java567/src/test/java/picocli/HelpAnsiHeuristicsTest.java
+++ b/picocli-tests-java567/src/test/java/picocli/HelpAnsiHeuristicsTest.java
@@ -360,6 +360,11 @@ public class HelpAnsiHeuristicsTest {
         environmentVariables.clear(ANSI_ENVIRONMENT_VARIABLES);
         environmentVariables.set("CLICOLOR", "0"); // hint disabled
         System.setProperty("os.name", "Windows");
+        // Clear the globally cached jansiConsole value that might
+        // have been set in a previous test to force the
+        // Ansi#isJansiConsoleInstalled method to recalculate
+        // the cached value.
+        Ansi.jansiConsole = null;
         assertTrue(Ansi.isWindows());
         assertFalse(Ansi.isPseudoTTY());
         assertFalse(Ansi.forceDisabled());

--- a/picocli-tests-java9plus/src/test/java/picocli/AutoCompleteSystemExitTest.java
+++ b/picocli-tests-java9plus/src/test/java/picocli/AutoCompleteSystemExitTest.java
@@ -1,9 +1,11 @@
 package picocli;
 
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
+import picocli.CommandLine.Help.Ansi;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -506,6 +508,15 @@ public class AutoCompleteSystemExitTest {
                 "# default Bash completions and the Readline default filename completions are performed.\n" +
                 "complete -F _complete_nondefault -o default nondefault nondefault.sh nondefault.bash\n",
             CommandLine.VERSION);
+    }
+
+    @BeforeAll
+    static void disableAnsi() {
+        // Clear the globally cached jansiConsole value that might
+        // have been set in a previous test to force the
+        // Ansi#isJansiConsoleInstalled method to recalculate
+        // the cached value.
+        Ansi.jansiConsole = null;
     }
 
     @Test

--- a/picocli-tests-java9plus/src/test/java/picocli/HelpAnsiHeuristicsTest.java
+++ b/picocli-tests-java9plus/src/test/java/picocli/HelpAnsiHeuristicsTest.java
@@ -612,6 +612,12 @@ public class HelpAnsiHeuristicsTest {
                     assertFalse(Ansi.hintEnabled());
 
                     assertFalse(Ansi.isJansiConsoleInstalled());
+
+                    // Clear the globally cached jansiConsole value that might
+                    // have been set in a previous test to force the
+                    // Ansi#isJansiConsoleInstalled method to recalculate
+                    // the cached value.
+                    Ansi.jansiConsole = null;
                     AnsiConsole.systemInstall();
                     try {
                         assertTrue(Ansi.isJansiConsoleInstalled());
@@ -628,6 +634,7 @@ public class HelpAnsiHeuristicsTest {
         restoreSystemProperties(() -> {
 
             System.setProperty("os.name", "Windows");
+            Ansi.jansiConsole = null;
             withEnvironmentVariable(ANSI_ENVIRONMENT_VARIABLES[0], null)
                 .and(ANSI_ENVIRONMENT_VARIABLES[1], null)
                 .and(ANSI_ENVIRONMENT_VARIABLES[2], null)
@@ -688,6 +695,7 @@ public class HelpAnsiHeuristicsTest {
                 restoreSystemProperties(() -> {
 
                     System.setProperty("os.name", "Windows");
+                    Ansi.jansiConsole = null;
                     assertTrue(Ansi.isWindows());
                     assertFalse(Ansi.isPseudoTTY());
                     assertFalse(Ansi.isJansiConsoleInstalled());

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -17805,7 +17805,14 @@ public class CommandLine {
                 if (!isTTY() && !isPseudoTTY())               { return false; }
                 return hintEnabled() || !isWindows() || isXterm() || isCygwin() || hasOsType();
             }
+            /** Cache the result for isJansiConsoleInstalled so it doesn't repeatedly
+             *  call Class#forName, which can cause performance issues. */
+            static Boolean jansiConsole;
             static boolean isJansiConsoleInstalled() {
+                if (jansiConsole == null) { jansiConsole = calcIsJansiConsoleInstalled(); }
+                return jansiConsole;
+            }
+            static boolean calcIsJansiConsoleInstalled() {
                 try {
                     // first check if JANSI was explicitly disabled _without loading any JANSI classes_:
                     // see https://github.com/remkop/picocli/issues/1106

--- a/src/test/java/picocli/HelpAnsiTest.java
+++ b/src/test/java/picocli/HelpAnsiTest.java
@@ -128,6 +128,10 @@ public class HelpAnsiTest {
 
         if (isWindows && !Ansi.AUTO.enabled()) {
             AnsiConsole.systemInstall();
+
+            // The previous Ansi.enabled() call caches the result for whether or not jansi is enabled.  Reset the cache value
+            // and force the Ansi.enabled() call to rescan the classpath for the jansi classes.
+            Ansi.jansiConsole = null;
             try {
                 assertTrue(Ansi.AUTO.enabled());
             } finally {

--- a/src/test/java/picocli/Issue1125_1538_OptionNameOrSubcommandAsOptionValue.java
+++ b/src/test/java/picocli/Issue1125_1538_OptionNameOrSubcommandAsOptionValue.java
@@ -9,6 +9,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.SystemErrRule;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Help.Ansi;
 import picocli.CommandLine.IParameterPreprocessor;
 import picocli.CommandLine.Model.ArgSpec;
 import picocli.CommandLine.Model.CommandSpec;
@@ -111,6 +112,11 @@ public class Issue1125_1538_OptionNameOrSubcommandAsOptionValue {
         //-x -y=123
         MyCommand obj = new MyCommand();
         CommandLine cmdLine = new CommandLine(obj);
+        // Clear the globally cached jansiConsole value that might
+        // have been set in a previous test to force the
+        // Ansi#isJansiConsoleInstalled method to recalculate
+        // the cached value.
+        Ansi.jansiConsole = null;
         int exitCode = cmdLine.execute("-x", "-y=123");
         assertEquals(2, exitCode);
         String expected = String.format("" +

--- a/src/test/java/picocli/ModelTransformerTest.java
+++ b/src/test/java/picocli/ModelTransformerTest.java
@@ -2,6 +2,7 @@ package picocli;
 
 import org.junit.Test;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Help.Ansi;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -34,7 +35,9 @@ public class ModelTransformerTest {
     @Test
     public void testUsage() {
         StringWriter sw = new StringWriter();
-        new CommandLine(new MyCommand()).usage(new PrintWriter(sw));
+        // Explicitly disable Ansi to make sure that the cached isJansiConsoleInstalled
+        // value doesn't inadvertently cause the usage help to be enabled.
+        new CommandLine(new MyCommand()).usage(new PrintWriter(sw), Ansi.OFF);
         String expected = String.format("" +
             "Usage: mycmd [-hV] [COMMAND]%n" +
             "  -h, --help      Show this help message and exit.%n" +

--- a/src/test/java/picocli/ModelTransformerTest.java
+++ b/src/test/java/picocli/ModelTransformerTest.java
@@ -36,7 +36,7 @@ public class ModelTransformerTest {
     public void testUsage() {
         StringWriter sw = new StringWriter();
         // Explicitly disable Ansi to make sure that the cached isJansiConsoleInstalled
-        // value doesn't inadvertently cause the usage help to be enabled.
+        // value doesn't inadvertently cause the usage help to enable ansi.
         new CommandLine(new MyCommand()).usage(new PrintWriter(sw), Ansi.OFF);
         String expected = String.format("" +
             "Usage: mycmd [-hV] [COMMAND]%n" +


### PR DESCRIPTION
Fixes #1975 

isJansiConsoleInstalled() was repeatedly called
in a loop from the TextTable#toString method,
which caused performance problems due to the
constant calls to Class#forName.  This change
caches the result from isJansiConsoleInstalled so
it doesn't repeatedly call Class#forName, which
cannot change at runtime.