### PR TITLE
[#2104] Usage shows alias used rather than command name

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -13928,6 +13928,10 @@ public class CommandLine {
         }
 
         private void processSubcommand(CommandLine subcommand, ParseResult.Builder builder, List<CommandLine> parsedCommands, Stack<String> args, Collection<ArgSpec> required, Set<ArgSpec> initialized, String[] originalArgs, List<Object> nowProcessing, String separator, String arg) {
+            if (!subcommand.getCommandName().equals(arg) && subcommand.getCommandSpec().aliases.contains(arg)) {
+                subcommand = subcommand.copyWithAliasAsName(arg);
+            }
+
             Tracer tracer = CommandLine.tracer();
             if (tracer.isDebug()) {
                 tracer.debug("Found subcommand '%s' (%s)", arg, subcommand.commandSpec.toString());}

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -245,7 +245,25 @@ public class CommandLine {
     }
 
     private CommandLine copy() {
-        CommandLine result = new CommandLine(commandSpec.copy(), factory); // create a new sub-hierarchy
+        return copyWithSpec(commandSpec.copy());
+    }
+
+    /**
+     * Copies this {@link CommandLine} with the given alias and name switched.
+     * @param alias the alias to use instead of the name.
+     * @return a copy of this {@link CommandLine} with the given alias and name switched.
+     */
+    private CommandLine copyWithAliasAsName(String alias) {
+        return copyWithSpec(commandSpec.copyWithAliasAsName(alias));
+    }
+
+    /**
+     * Copies this {@link CommandLine} with the given {@link CommandSpec}.
+     * @param commandSpec the {@link CommandSpec} to use instead.
+     * @return a copy of this {@link CommandLine} with the given {@link CommandSpec}.
+     */
+    private CommandLine copyWithSpec(CommandSpec commandSpec) {
+        CommandLine result = new CommandLine(commandSpec, factory); // create a new sub-hierarchy
         result.err = err;
         result.out = out;
         result.colorScheme = colorScheme;

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -6308,6 +6308,34 @@ public class CommandLine {
             private CommandSpec copy() {
                 Object obj = userObject.type == null ? userObject.instance : userObject.type;
                 CommandSpec result = obj == null ? CommandSpec.create() : CommandSpec.forAnnotatedObject(obj, userObject.factory);
+                copyReferencesTo(result);
+                return result;
+            }
+
+            /**
+             * Copies this {@link CommandSpec} with the given alias and name switched.
+             * @param alias the alias to use instead of the name.
+             * @return a copy of this {@link CommandSpec} with the given alias and name switched.
+             */
+            private CommandSpec copyWithAliasAsName(String alias) {
+                final CommandSpec result = new CommandSpec(userObject);
+                copyReferencesTo(result);
+                copyMapContentsTo(result);
+
+                result.name = alias;
+                result.aliases = new LinkedHashSet<>();
+                result.aliases.add(name);
+                result.aliases.addAll(aliases);
+                result.aliases.remove(alias);
+                return result;
+            }
+
+            /**
+             * Copies field references into the given {@link CommandSpec}.
+             *
+             * @param result the {@link CommandSpec} instance to copy values into.
+             */
+            private void copyReferencesTo(CommandSpec result) {
                 result.commandLine = commandLine;
                 result.parent = parent;
                 result.methodParams = methodParams;
@@ -6334,25 +6362,28 @@ public class CommandLine {
                 result.parser(parser);
                 result.inherited = inherited;
                 result.scopeType = scopeType;
+            }
 
-                // TODO if this CommandSpec was created/modified via the programmatic API,
-                //   we need to copy all attributes that are modifiable via the programmatic API
-                //   and point them to this CommandSpec instance.
-//                result.commands.clear();                result.commands.putAll(this.commands);
-//                result.optionsByNameMap.clear();        result.optionsByNameMap.putAll(this.optionsByNameMap);
-//                result.negatedOptionsByNameMap.clear(); result.negatedOptionsByNameMap.putAll(this.negatedOptionsByNameMap);
-//                result.posixOptionsByKeyMap.clear();    result.posixOptionsByKeyMap.putAll(this.posixOptionsByKeyMap);
-//                result.mixins.clear();                  result.mixins.putAll(this.mixins);
-//                result.mixinAnnotatedElements.clear();  result.mixinAnnotatedElements.putAll(this.mixinAnnotatedElements);
-//                result.requiredArgs.clear();            result.requiredArgs.addAll(requiredArgs);
-//                result.args.clear();                    result.args.addAll(args);
-//                result.options.clear();                 result.options.addAll(options);
-//                result.positionalParameters.clear();    result.positionalParameters.addAll(positionalParameters);
-//                result.unmatchedArgs.clear();           result.unmatchedArgs.addAll(unmatchedArgs);
-//                result.specElements.clear();            result.specElements.addAll(specElements);
-//                result.parentCommandElements.clear();   result.parentCommandElements.addAll(parentCommandElements);
-//                result.groups.clear();                  result.groups.addAll(groups);
-                return result;
+            /**
+             * Copies field map contents into the given {@link CommandSpec}.
+             *
+             * @param result the {@link CommandSpec} instance to copy map contents into.
+             */
+            private void copyMapContentsTo(CommandSpec result) {
+                result.commands.clear();                result.commands.putAll(this.commands);
+                result.optionsByNameMap.clear();        result.optionsByNameMap.putAll(this.optionsByNameMap);
+                result.negatedOptionsByNameMap.clear(); result.negatedOptionsByNameMap.putAll(this.negatedOptionsByNameMap);
+                result.posixOptionsByKeyMap.clear();    result.posixOptionsByKeyMap.putAll(this.posixOptionsByKeyMap);
+                result.mixins.clear();                  result.mixins.putAll(this.mixins);
+                result.mixinAnnotatedElements.clear();  result.mixinAnnotatedElements.putAll(this.mixinAnnotatedElements);
+                result.requiredArgs.clear();            result.requiredArgs.addAll(requiredArgs);
+                result.args.clear();                    result.args.addAll(args);
+                result.options.clear();                 result.options.addAll(options);
+                result.positionalParameters.clear();    result.positionalParameters.addAll(positionalParameters);
+                result.unmatchedArgs.clear();           result.unmatchedArgs.addAll(unmatchedArgs);
+                result.specElements.clear();            result.specElements.addAll(specElements);
+                result.parentCommandElements.clear();   result.parentCommandElements.addAll(parentCommandElements);
+                result.groups.clear();                  result.groups.addAll(groups);
             }
 
             /** Creates and returns a new {@code CommandSpec} without any associated user object. */

--- a/src/test/java/picocli/HelpSubCommandTest.java
+++ b/src/test/java/picocli/HelpSubCommandTest.java
@@ -529,4 +529,22 @@ public class HelpSubCommandTest {
             "                                              txt).%n");
         assertEquals(expected, actual);
     }
+
+    @Test
+    public void testUsageHelpForAliasedSubcommands() {
+        @Command(name = "sub", aliases = "alias", mixinStandardHelpOptions = true) class Sub {}
+        @Command(name = "app", subcommands = {Sub.class}) class App {}
+
+        StringWriter out = new StringWriter();
+        CommandLine app = new CommandLine(new App(), new InnerClassFactory(this));
+        app.setOut(new PrintWriter(out));
+        ParseResult result = app.parseArgs("alias", "--help");
+        CommandLine.printHelpIfRequested(result);
+
+        final String expected = format("" +
+            "Usage: app alias [-hV]%n" +
+            "  -h, --help      Show this help message and exit.%n" +
+            "  -V, --version   Print version information and exit.%n");
+        assertEquals(expected, out.toString());
+    }
 }


### PR DESCRIPTION
First attempt at a fix for #2104

> It may not be easy to build bookkeeping to keep track of this. Such bookkeeping also needs to handle scenarios like nested sub-subcommands and repeatable subcommands.

Looking at repeatable subcommands gave me the inspiration for this PR - for repeatable subcommands there seems to be some copying of `CommandLine` and so this PR takes a similar approach: When a subcommand alias is used, the `CommandLine` is copied with name and alias swapped.

I imagine the need for additional `CommandLine` instances here might be seen as a hack. And I suspect there's potentially some mileage in adding a `parsedName` field rather swapping alias/name. But I figure this was worth getting feedback on.

> Secondly, the display part. Currently help is static: it's not designed to change depending on user input (only the error message is, but that isn't part of the usage help message).
> 
> There's no parser state available to the logic that constructs the usage help message. I imagine we would have to use a static variable (or something similar) to store the user-specified command name/alias, to make that alias available to the logic that constructs the usage help message. If you can think of a better solution, ideas are welcome!

Yeah, I was surprised the `CommandLine` doesn't retain access to the `ParseResult`. I've tried to avoid resorting to static stuff for now, but can see that could be necessary.

> Finally, the help is designed to be highly customizable. If applications have tests that assert the exact help message, then these tests may break, that's unavoidable.
> 
> But other than that, any changes we introduce here should not impact other applications who have customized their help message, those customizations should continue to work as before.

Presumably the PR could cause some side effects here with the `CommandLine` name having changed. I guess the new behaviour could be hidden behind some new optional flag. Although I'm not sure where best that option would fit off the top of my head.