### PR TITLE
Fix NPE in jline3 Example as ConfigurationPath cannot be null anymore

### DIFF
--- a/picocli-shell-jline3/README.md
+++ b/picocli-shell-jline3/README.md
@@ -226,7 +226,7 @@ public class Example {
         try {
             Supplier<Path> workDir = () -> Paths.get(System.getProperty("user.dir"));
             // set up JLine built-in commands
-            Builtins builtins = new Builtins(workDir, null, null);
+            Builtins builtins = new Builtins(workDir, new ConfigurationPath(workDir.get(), workDir.get()), null);
             builtins.rename(Builtins.Command.TTOP, "top");
             builtins.alias("zle", "widget");
             builtins.alias("bindkey", "keymap");

--- a/picocli-shell-jline3/src/test/java/picocli/shell/jline3/example/Example.java
+++ b/picocli-shell-jline3/src/test/java/picocli/shell/jline3/example/Example.java
@@ -134,7 +134,7 @@ public class Example {
         try {
             Supplier<Path> workDir = () -> Paths.get(System.getProperty("user.dir"));
             // set up JLine built-in commands
-            Builtins builtins = new Builtins(workDir, null, null);
+            Builtins builtins = new Builtins(workDir, new ConfigurationPath(workDir.get(), workDir.get()), null);
             builtins.rename(Builtins.Command.TTOP, "top");
             builtins.alias("zle", "widget");
             builtins.alias("bindkey", "keymap");


### PR DESCRIPTION
ConfigurationPath cannot be null anymore since commit 9706ead in jline3. An Objects.requireNonNull check now requires a valid ConfigurationPath.