### PR TITLE
Regex based name transformations for options in Mixins to allow for M…

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -9595,6 +9595,72 @@ class MyApp : Runnable {
 }
 ----
 
+==== Reusing a Mixin within the same command
+
+Here is an example on how a Mixin can be reused in the same command.
+Option names within the mixin can be transformed using regular expressions to create a command line without
+name collisions.
+
+.Java
+[source,java,role="primary"]
+----
+public class DbParams {
+
+    @Option(names={"--url"})
+    private String url;
+
+    @Option(names={"--user"})
+    private String user;
+
+    @Option(names={"--pass"})
+    private String pass;
+}
+
+@Command(name = "compare", description = "Example reuse with @Mixin annotation.")
+public class MyCommand {
+
+    // Adds the options defined in DbParams to this command with names transformed.
+    // The options exposed by this Mixin will be --firstDb.url, --firstDb.user, --firstDb.pass
+    @Mixin(optionNameTransformations = {"^--(.*)$", "--firstDb.$1"})
+    private DbParams firstDb;
+
+    // Adds the options defined in DbParams to this command with names transformed.
+    // The options exposed by this Mixin will be --secondDb.url, --secondDb.user, --secondDb.pass
+    @Mixin(optionNameTransformations = {"^--(.*)$", "--secondDb.$1"})
+    private DbParams secondDb;
+}
+----
+
+.Kotlin
+[source,kotlin,role="secondary"]
+----
+public class DbParams {
+
+    @Option(names = ["--url"])
+    private url: String
+
+    @Option(names = ["--user"])
+    private user: String
+
+    @Option(names = ["--pass"])
+    private pass: String
+}
+
+@Command(name = "compare", description = ["Example reuse with @Mixin annotation."])
+public class MyCommand {
+
+    // Adds the options defined in DbParams to this command with names transformed.
+    // The options exposed by this Mixin will be --firstDb.url, --firstDb.user, --firstDb.pass
+    @Mixin(optionNameTransformations = ["^--(.*)$", "--firstDb.$1"])
+    var firstDb: DbParams
+
+    // Adds the options defined in DbParams to this command with name transformed.
+    // The options exposed by this Mixin will be --secondDb.url, --secondDb.user, --secondDb.pass
+    @Mixin(optionNameTransformations = ["^--(.*)$", "--secondDb.$1"])
+    var secondDb: DbParams
+}
+----
+
 ==== Accessing the Mixee from a Mixin
 
 Sometimes you need to write a Mixin class that accesses the mixee (the command where it is mixed in).

--- a/picocli-codegen/src/main/java/picocli/codegen/annotation/processing/MixinInfo.java
+++ b/picocli-codegen/src/main/java/picocli/codegen/annotation/processing/MixinInfo.java
@@ -16,6 +16,7 @@ import java.util.List;
  */
 class MixinInfo {
     private final String mixinName;
+    private final String[] optionNameTransformations;
     private final IAnnotatedElement annotatedElement;
     private final VariableElement element;
     private final CommandSpec mixin;
@@ -29,6 +30,7 @@ class MixinInfo {
             name = element.getSimpleName().toString();
         }
         this.mixinName = name;
+        this.optionNameTransformations = element.getAnnotation(CommandLine.Mixin.class).optionNameTransformations();
         Element targetType = element.getEnclosingElement();
         int position = -1;
         if (EnumSet.of(ElementKind.METHOD, ElementKind.CONSTRUCTOR).contains(targetType.getKind())) {

--- a/picocli-codegen/src/main/java/picocli/codegen/annotation/processing/TypedMember.java
+++ b/picocli-codegen/src/main/java/picocli/codegen/annotation/processing/TypedMember.java
@@ -114,6 +114,10 @@ class TypedMember implements CommandLine.Model.IAnnotatedElement, CommandLine.Mo
         return empty(annotationName) ? getName() : annotationName;
     }
 
+    public String[] getOptionNameTransformations() {
+        return getAnnotation(CommandLine.Mixin.class).optionNameTransformations();
+    }
+
     static String propertyName(String methodName) {
         if (methodName.length() > 3 && (methodName.startsWith("get") || methodName.startsWith("set"))) { return decapitalize(methodName.substring(3)); }
         return decapitalize(methodName);

--- a/src/test/java/picocli/MixinTest.java
+++ b/src/test/java/picocli/MixinTest.java
@@ -27,6 +27,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.*;
@@ -1099,5 +1100,24 @@ public class MixinTest {
     public void testIssue1836CommandAliasOnMixin() {
         Help help = new Help(new App_Issue1836());
         assertEquals("list, ls", help.commandList().trim());
+    }
+
+    @Test
+    public void testOptionNameTransformations() {
+        class ReusableMixin {
+            @Option(names = "--url")
+            String  url;
+        }
+        class Application {
+            @Mixin(optionNameTransformations = {"^--(.*)$", "--firstDb.$1"})
+            ReusableMixin firstDb;
+            @Mixin(optionNameTransformations = {"^--(.*)$", "--secondDb.$1"})
+            ReusableMixin secondDb;
+        }
+        Application application = new Application();
+        CommandLine commandLine = new CommandLine(application, new InnerClassFactory(this));
+        List<OptionSpec> options = commandLine.getCommandSpec().options();
+        assertArrayEquals(options.get(0).names(), new String[]{"--firstDb.url"});
+        assertArrayEquals(options.get(1).names(), new String[]{"--secondDb.url"});
     }
 }

--- a/src/test/java/picocli/ModelArgSpecTest.java
+++ b/src/test/java/picocli/ModelArgSpecTest.java
@@ -243,6 +243,7 @@ public class ModelArgSpecTest {
         public <T extends Annotation> T getAnnotation(Class<T> annotationClass) { return null;}
         public String getName() {return name;}
         public String getMixinName() {return null;}
+        public String[] getOptionNameTransformations() {return null;}
         public boolean isArgSpec() {return false;}
         public boolean isOption() {return false;}
         public boolean isParameter() {return false;}


### PR DESCRIPTION
This feature allows a class to be used as a mixin multiple times in a command if option name transformations for each mixin are set-up as such that there is going to be no parameter name collision.