### PR TITLE
IAnnotatedElementProvider to Access to ArgSpec/OptionSpec setter/getter field/method

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -6011,9 +6011,9 @@ public class CommandLine {
         }
         
         /**
-         * Provides access to the underlying annotated element for inspection
+         * Provides access to the underlying {@link AnnotatedElement}.
          */
-        public interface IReflector {
+        public interface IAnnotatedElementProvider {
         	
         	/**
         	 * @return {@link AnnotatedElement} used for reflection - field, method, ...
@@ -12105,7 +12105,7 @@ public class CommandLine {
             }
         }
 
-        static class FieldBinding implements IGetter, ISetter, IScoped, IReflector {
+        static class FieldBinding implements IGetter, ISetter, IScoped, IAnnotatedElementProvider {
             private final IScope scope;
             private final Field field;
             FieldBinding(Object scope, Field field) { this(ObjectScope.asScope(scope), field); }
@@ -12145,7 +12145,7 @@ public class CommandLine {
 				return field;
 			}
         }
-        static class MethodBinding implements IGetter, ISetter, IScoped, IReflector {
+        static class MethodBinding implements IGetter, ISetter, IScoped, IAnnotatedElementProvider {
             private final IScope scope;
             private final Method method;
             private final CommandSpec spec;

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -6009,6 +6009,18 @@ public class CommandLine {
              *  @return {@link IScope} instance */
             IScope getScope();
         }
+        
+        /**
+         * Provides access to the underlying annotated element for inspection
+         */
+        public interface IReflector {
+        	
+        	/**
+        	 * @return {@link AnnotatedElement} used for reflection - field, method, ...
+        	 */
+        	AnnotatedElement getAnnotatedElement();
+        	
+        }
 
         /** Customizable getter for obtaining the current value of an option or positional parameter.
          * When an option or positional parameter is matched on the command line, its getter or setter is invoked to capture the value.
@@ -12093,7 +12105,7 @@ public class CommandLine {
             }
         }
 
-        static class FieldBinding implements IGetter, ISetter, IScoped {
+        static class FieldBinding implements IGetter, ISetter, IScoped, IReflector {
             private final IScope scope;
             private final Field field;
             FieldBinding(Object scope, Field field) { this(ObjectScope.asScope(scope), field); }
@@ -12128,8 +12140,12 @@ public class CommandLine {
                 return String.format("%s(%s %s.%s)", getClass().getSimpleName(), field.getType().getName(),
                         field.getDeclaringClass().getName(), field.getName());
             }
+			@Override
+			public AnnotatedElement getAnnotatedElement() {
+				return field;
+			}
         }
-        static class MethodBinding implements IGetter, ISetter, IScoped {
+        static class MethodBinding implements IGetter, ISetter, IScoped, IReflector {
             private final IScope scope;
             private final Method method;
             private final CommandSpec spec;
@@ -12166,6 +12182,10 @@ public class CommandLine {
             public String toString() {
                 return String.format("%s(%s)", getClass().getSimpleName(), method);
             }
+			@Override
+			public AnnotatedElement getAnnotatedElement() {
+				return method;
+			}
         }
         private static class PicocliInvocationHandler implements InvocationHandler {
             final Map<String, Object> map = new HashMap<String, Object>();

--- a/src/test/java/picocli/IAnnotatedElementProviderTest.java
+++ b/src/test/java/picocli/IAnnotatedElementProviderTest.java
@@ -26,39 +26,39 @@ import org.junit.Test;
 
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Model.IReflector;
+import picocli.CommandLine.Model.IAnnotatedElementProvider;
 import picocli.CommandLine.Model.OptionSpec;
 import picocli.CommandLine.Option;
 
 /**
- * Tests for {@link IReflector}.
+ * Tests for {@link IAnnotatedElementProvider}.
  */
-public class IReflectorTest {
+public class IAnnotatedElementProviderTest {
 
     @Before public void setUp() { System.clearProperty("picocli.trace"); }
     @After public void tearDown() { System.clearProperty("picocli.trace"); }
-
+    
     @Command(name = "reflector-test")
-    static class ReflectorTest {
+    static class IAnnotatedElementProviderTestCommand {
         @Option(names = "-a") int a;
         @Option(names = "-b") long b;
-
     }
 
     @Test
-    public void testFieldReflector() throws Exception {
-        ReflectorTest command = new ReflectorTest();
+    public void testFieldAccess() throws Exception {
+    	IAnnotatedElementProviderTestCommand command = new IAnnotatedElementProviderTestCommand();
         CommandLine commandLine = new CommandLine(command);
         CommandSpec spec = commandLine.getCommandSpec();
         for (OptionSpec option: spec.options()) {
-        	assertTrue(option.setter() instanceof IReflector);
-        	assertTrue(option.getter() instanceof IReflector);
+        	assertTrue(option.setter() instanceof IAnnotatedElementProvider);
+        	assertTrue(option.getter() instanceof IAnnotatedElementProvider);
         	
-        	assertTrue(((IReflector) option.setter()).getAnnotatedElement() instanceof Field);
-        	assertTrue(((IReflector) option.getter()).getAnnotatedElement() instanceof Field);
+        	assertTrue(((IAnnotatedElementProvider) option.setter()).getAnnotatedElement() instanceof Field);
+        	assertTrue(((IAnnotatedElementProvider) option.getter()).getAnnotatedElement() instanceof Field);
         	        	
-        	assertEquals(ReflectorTest.class, ((Field) ((IReflector) option.setter()).getAnnotatedElement()).getDeclaringClass());
-        	assertEquals(ReflectorTest.class, ((Field) ((IReflector) option.getter()).getAnnotatedElement()).getDeclaringClass());        	
+        	assertEquals(IAnnotatedElementProviderTestCommand.class, ((Field) ((IAnnotatedElementProvider) option.setter()).getAnnotatedElement()).getDeclaringClass());
+        	assertEquals(IAnnotatedElementProviderTestCommand.class, ((Field) ((IAnnotatedElementProvider) option.getter()).getAnnotatedElement()).getDeclaringClass());        	
         }
     }
+    
 }

--- a/src/test/java/picocli/IReflectorTest.java
+++ b/src/test/java/picocli/IReflectorTest.java
@@ -1,0 +1,64 @@
+/*
+   Copyright 2017 Remko Popma
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package picocli;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.Field;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Model.IReflector;
+import picocli.CommandLine.Model.OptionSpec;
+import picocli.CommandLine.Option;
+
+/**
+ * Tests for {@link IReflector}.
+ */
+public class IReflectorTest {
+
+    @Before public void setUp() { System.clearProperty("picocli.trace"); }
+    @After public void tearDown() { System.clearProperty("picocli.trace"); }
+
+    @Command(name = "reflector-test")
+    static class ReflectorTest {
+        @Option(names = "-a") int a;
+        @Option(names = "-b") long b;
+
+    }
+
+    @Test
+    public void testFieldReflector() throws Exception {
+        ReflectorTest command = new ReflectorTest();
+        CommandLine commandLine = new CommandLine(command);
+        CommandSpec spec = commandLine.getCommandSpec();
+        for (OptionSpec option: spec.options()) {
+        	assertTrue(option.setter() instanceof IReflector);
+        	assertTrue(option.getter() instanceof IReflector);
+        	
+        	assertTrue(((IReflector) option.setter()).getAnnotatedElement() instanceof Field);
+        	assertTrue(((IReflector) option.getter()).getAnnotatedElement() instanceof Field);
+        	        	
+        	assertEquals(ReflectorTest.class, ((Field) ((IReflector) option.setter()).getAnnotatedElement()).getDeclaringClass());
+        	assertEquals(ReflectorTest.class, ((Field) ((IReflector) option.getter()).getAnnotatedElement()).getDeclaringClass());        	
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces IAnnotatedElementProvider interface implemented by FieldBinding and MethodBinding.
This allows to access underlying fields/methods of parameters and options.

See also issue #2325.