### PR TITLE
Added support for using model transformers with mixinx.

### DIFF
--- a/picocli-codegen/src/main/java/picocli/codegen/annotation/processing/TypedMember.java
+++ b/picocli-codegen/src/main/java/picocli/codegen/annotation/processing/TypedMember.java
@@ -114,6 +114,15 @@ class TypedMember implements CommandLine.Model.IAnnotatedElement, CommandLine.Mo
         return empty(annotationName) ? getName() : annotationName;
     }
 
+    @Override
+    public Class<? extends CommandLine.IModelTransformer> getModelTransformer() {
+        if (isMixin()) {
+            return getAnnotation(CommandLine.Mixin.class).modelTransformer();
+        } else {
+            return null;
+        }
+    }
+
     static String propertyName(String methodName) {
         if (methodName.length() > 3 && (methodName.startsWith("get") || methodName.startsWith("set"))) { return decapitalize(methodName.substring(3)); }
         return decapitalize(methodName);

--- a/src/test/java/picocli/MixinTest.java
+++ b/src/test/java/picocli/MixinTest.java
@@ -27,6 +27,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.*;
@@ -1099,5 +1101,52 @@ public class MixinTest {
     public void testIssue1836CommandAliasOnMixin() {
         Help help = new Help(new App_Issue1836());
         assertEquals("list, ls", help.commandList().trim());
+    }
+
+    public static class MixinReuseModeTransformer implements IModelTransformer {
+        @Override
+        public CommandSpec transform(CommandSpec commandSpec) {
+            String prefix = commandSpec.name();
+            ArrayList<OptionSpec> options = new ArrayList<OptionSpec>(commandSpec.options());
+            for (OptionSpec option : options) {
+                commandSpec.remove(option);
+                OptionSpec.Builder optionBuilder = option.toBuilder();
+                String[] names = optionBuilder.names();
+                String[] newNames = new String[names.length];
+                for (int i = 0; i < names.length; i++) {
+                    String name = names[i];
+                    String newName = "--" + prefix + name.substring(2, 3).toUpperCase() + name.substring(3);
+                    newNames[i] = newName;
+                }
+                optionBuilder.names(newNames);
+                String defaultValue = optionBuilder.defaultValue();
+                if (defaultValue.startsWith("${env:")) {
+                    optionBuilder.defaultValue("${env:" + prefix.toUpperCase() + "_" + defaultValue.substring(6, defaultValue.length() - 1).toUpperCase() + "}");
+                }
+                commandSpec.add(optionBuilder.build());
+            }
+            return commandSpec;
+        }
+    }
+
+    @Test
+    public void testModelTransformation() {
+        class ReusableMixin {
+            @Option(names = "--url", defaultValue = "${env:URL}")
+            String  url;
+        }
+        class Application {
+            @Mixin(modelTransformer = MixinReuseModeTransformer.class)
+            ReusableMixin first;
+            @Mixin(modelTransformer = MixinReuseModeTransformer.class)
+            ReusableMixin second;
+        }
+        Application application = new Application();
+        CommandLine commandLine = new CommandLine(application, new InnerClassFactory(this));
+        List<OptionSpec> options = commandLine.getCommandSpec().options();
+        assertArrayEquals(new String[]{"--firstUrl"}, options.get(0).names());
+        assertEquals("${env:FIRST_URL}", options.get(0).defaultValueString());
+        assertArrayEquals(new String[]{"--secondUrl"}, options.get(1).names());
+        assertEquals("${env:SECOND_URL}", options.get(1).defaultValueString());
     }
 }

--- a/src/test/java/picocli/ModelArgSpecTest.java
+++ b/src/test/java/picocli/ModelArgSpecTest.java
@@ -243,6 +243,7 @@ public class ModelArgSpecTest {
         public <T extends Annotation> T getAnnotation(Class<T> annotationClass) { return null;}
         public String getName() {return name;}
         public String getMixinName() {return null;}
+        public Class<? extends CommandLine.IModelTransformer> getModelTransformer() { return null; }
         public boolean isArgSpec() {return false;}
         public boolean isOption() {return false;}
         public boolean isParameter() {return false;}


### PR DESCRIPTION
Mixins can use model transformers to make changes to the model. This is useful to allow for mix-in reuse while changing option names and void clashes.