### PR TITLE
Fix #2498 by dropping down hyphen to underscore in autocomplete bash script

### DIFF
--- a/src/main/java/picocli/AutoComplete.java
+++ b/src/main/java/picocli/AutoComplete.java
@@ -550,18 +550,22 @@ public class AutoComplete {
 
     private static void createSubHierarchy(String scriptName, String parentWithoutTopLevelCommand, CommandLine commandLine, List<CommandDescriptor> out) {
         // breadth-first: generate command lists and function calls for predecessors + each subcommand
-        Map<String, Integer> functionAliasCounts = new HashMap<>();
+        Map<String, Integer> functionAliasCounts = new HashMap<String, Integer>();
         for (Map.Entry<String, CommandLine> entry : commandLine.getSubcommands().entrySet()) {
             CommandSpec spec = entry.getValue().getCommandSpec();
             if (spec.usageMessage().hidden()) { continue; } // #887 skip hidden subcommands
             String commandName = entry.getKey(); // may be an alias
             String functionNameWithoutPrefix = bashify(concat("_", parentWithoutTopLevelCommand.replace(' ', '_'), commandName));
-            int functionAliasCount = functionAliasCounts.merge(functionNameWithoutPrefix,  1, Integer::sum);
-            if (functionAliasCount > 1) {
+            Integer functionAliasCount = functionAliasCounts.get(functionNameWithoutPrefix);
+            if (functionAliasCount == null) {
+                functionAliasCount = 0;
+            }
+            functionAliasCounts.put(functionNameWithoutPrefix, functionAliasCount + 1);
+            if (functionAliasCount > 0) {
                 functionNameWithoutPrefix = concat("_", functionNameWithoutPrefix, "alias", String.valueOf(functionAliasCount));
             }
             String functionName = concat("_", "_picocli", scriptName, functionNameWithoutPrefix);
-            String parentFunctionName = parentWithoutTopLevelCommand.isEmpty()
+            String parentFunctionName = parentWithoutTopLevelCommand.length() == 0
                 ? concat("_", "_picocli", scriptName)
                 : concat("_", "_picocli", scriptName, bashify(parentWithoutTopLevelCommand.replace(' ', '_')));
 

--- a/src/main/java/picocli/AutoComplete.java
+++ b/src/main/java/picocli/AutoComplete.java
@@ -260,7 +260,7 @@ public class AutoComplete {
             char c = value.charAt(i);
             if (Character.isLetterOrDigit(c) || c == '_') {
                 builder.append(c);
-            } else if (Character.isSpaceChar(c)) {
+            } else if (Character.isSpaceChar(c) || c == '-') {
                 builder.append('_');
             }
         }


### PR DESCRIPTION
As discussed in #2498, this should probably fix the duplicate-name issue. I still think that the alias function is a duplicate which could be completely removed, but this should be an important patch nonetheless.

Please let me know if this patch no longer conforms with the intention of `bashify`.