### PR TITLE
Fix #2501 by including function in option auto complete function name

### DIFF
--- a/src/main/java/picocli/AutoComplete.java
+++ b/src/main/java/picocli/AutoComplete.java
@@ -777,11 +777,17 @@ public class AutoComplete {
     }
 
     private static void generateCompletionCandidates(StringBuilder buff, OptionSpec f) {
-        buff.append(format("  local %s_option_args=(\"%s\") # %s values\n",
-                bashify(f.paramLabel()),
-                concat("\" \"", extract(f.completionCandidates())).trim(),
-                f.longestName()));
+        buff.append(generateCompletionCandidates(f));
     }
+
+    private static String generateCompletionCandidates(OptionSpec f) {
+        return format("  local %s_%s_option_args=(\"%s\") # %s values\n",
+            bashify(f.longestName()).replaceFirst("^_+", ""),
+            bashify(f.paramLabel()),
+            concat("\" \"", extract(f.completionCandidates())).trim(),
+            f.longestName());
+    }
+
     private static List<String> extract(Iterable<String> generator) {
         List<String> result = new ArrayList<String>();
         for (String e : generator) {
@@ -848,7 +854,7 @@ public class AutoComplete {
             if (option.completionCandidates() != null) {
                 buff.append(format("%s    %s)\n", indent, concat("|", option.names(), null, new SingleQuoteFunction()))); // "    -u|--timeUnit)\n"
                 buff.append(format("%s      local IFS=$'\\n'\n", indent));
-                buff.append(format("%s      COMPREPLY=( $( compReplyArray \"${%s_option_args[@]}\" ) )\n", indent, bashify(option.paramLabel())));
+                buff.append(format("%s      COMPREPLY=( $( compReplyArray \"${%s_option_args[@]}\" ) )\n", indent, generateCompletionCandidates(option)));
                 buff.append(format("%s      return $?\n", indent));
                 buff.append(format("%s      ;;\n", indent));
             } else if (type.equals(File.class) || "java.nio.file.Path".equals(type.getName())) {

--- a/src/main/java/picocli/AutoComplete.java
+++ b/src/main/java/picocli/AutoComplete.java
@@ -550,18 +550,22 @@ public class AutoComplete {
 
     private static void createSubHierarchy(String scriptName, String parentWithoutTopLevelCommand, CommandLine commandLine, List<CommandDescriptor> out) {
         // breadth-first: generate command lists and function calls for predecessors + each subcommand
-        Map<String, Integer> functionAliasCounts = new HashMap<>();
+        Map<String, Integer> functionAliasCounts = new HashMap<String, Integer>();
         for (Map.Entry<String, CommandLine> entry : commandLine.getSubcommands().entrySet()) {
             CommandSpec spec = entry.getValue().getCommandSpec();
             if (spec.usageMessage().hidden()) { continue; } // #887 skip hidden subcommands
             String commandName = entry.getKey(); // may be an alias
             String functionNameWithoutPrefix = bashify(concat("_", parentWithoutTopLevelCommand.replace(' ', '_'), commandName));
-            int functionAliasCount = functionAliasCounts.merge(functionNameWithoutPrefix,  1, Integer::sum);
-            if (functionAliasCount > 1) {
+            Integer functionAliasCount = functionAliasCounts.get(functionNameWithoutPrefix);
+            if (functionAliasCount == null) {
+                functionAliasCount = 0;
+            }
+            functionAliasCounts.put(functionNameWithoutPrefix, functionAliasCount + 1);
+            if (functionAliasCount > 0) {
                 functionNameWithoutPrefix = concat("_", functionNameWithoutPrefix, "alias", String.valueOf(functionAliasCount));
             }
             String functionName = concat("_", "_picocli", scriptName, functionNameWithoutPrefix);
-            String parentFunctionName = parentWithoutTopLevelCommand.isEmpty()
+            String parentFunctionName = parentWithoutTopLevelCommand.length() == 0
                 ? concat("_", "_picocli", scriptName)
                 : concat("_", "_picocli", scriptName, bashify(parentWithoutTopLevelCommand.replace(' ', '_')));
 

--- a/src/main/java/picocli/AutoComplete.java
+++ b/src/main/java/picocli/AutoComplete.java
@@ -260,7 +260,7 @@ public class AutoComplete {
             char c = value.charAt(i);
             if (Character.isLetterOrDigit(c) || c == '_') {
                 builder.append(c);
-            } else if (Character.isSpaceChar(c)) {
+            } else if (Character.isSpaceChar(c) || c == '-') {
                 builder.append('_');
             }
         }


### PR DESCRIPTION
This fixes #2501. Note that this depends on #2499 being merged first, and relates to it closely in the structure of the issue. The fix here should be pretty simple, extending the auto generate function name of the option to include the name of the function.