### PR TITLE
Support jline.jansi alongside fusesource.jansi

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -17988,8 +17988,7 @@ public class CommandLine {
                     } catch (ClassNotFoundException e) {
                         ansiConsole = Class.forName("org.jline.jansi.AnsiConsole");
                     }
-                    Object out = ansiConsole.getDeclaredMethod("out").invoke(null);
-                    return out == System.out;
+                    return (Boolean) ansiConsole.getDeclaredMethod("isInstalled").invoke(null);
                 } catch (Exception reflectionFailed) {
                     return false;
                 }

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -17988,7 +17988,13 @@ public class CommandLine {
                     } catch (ClassNotFoundException e) {
                         ansiConsole = Class.forName("org.jline.jansi.AnsiConsole");
                     }
-                    return (Boolean) ansiConsole.getDeclaredMethod("isInstalled").invoke(null);
+                    try {
+                        return (Boolean) ansiConsole.getDeclaredMethod("isInstalled").invoke(null);
+                    } catch (ReflectiveOperationException e) {
+                        // isInstalled was "only" added in 2.1.0, try to support older jansi
+                        Field out = ansiConsole.getField("out");
+                        return out.get(null) == System.out;
+                    }
                 } catch (Exception reflectionFailed) {
                     return false;
                 }

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -17954,29 +17954,42 @@ public class CommandLine {
                 if (jansiInstalled == null) { jansiInstalled = calcIsJansiConsoleInstalled(); }
                 return jansiInstalled;
             }
-            /** Returns {@code false} if system property {@code org.fusesource.jansi.Ansi.disable} is set to {@code "true"}
-             * (case-insensitive); otherwise, returns {@code false} if the Jansi library is in the classpath but has been disabled
-             * (either via system property {@code org.fusesource.jansi.Ansi.disable} or via a Jansi API call);
+            /** Returns {@code false} if either system properties {@code org.fusesource.jansi.Ansi.disable}
+             * or {@code org.jline.jansi.Ansi.disable} are set to {@code "true"} (case-insensitive);
+             * otherwise, returns {@code false} if the Jansi library is in the classpath but has been disabled
+             * (either via the aforementioned system properties or via a Jansi API call);
              * otherwise, returns {@code true} if the Jansi library is in the classpath and has been installed.
              */
             static boolean calcIsJansiConsoleInstalled() {
                 try {
                     // first check if JANSI was explicitly disabled _without loading any JANSI classes_:
                     // see https://github.com/remkop/picocli/issues/1106
-                    if (Boolean.getBoolean("org.fusesource.jansi.Ansi.disable")) {
+                    if (Boolean.getBoolean("org.jline.jansi.Ansi.disable") ||
+                        Boolean.getBoolean("org.fusesource.jansi.Ansi.disable")) {
                         return false;
                     }
-                    // the Ansi class internally also checks system property "org.fusesource.jansi.Ansi.disable"
+                    // the Ansi class internally also checks system property "org.jline.jansi.Ansi.disable"
                     // but may also have been set with Ansi.setEnabled or a custom detector
-                    Class<?> ansi = Class.forName("org.fusesource.jansi.Ansi");
+                    Class<?> ansi;
+                    try {
+                        // Try to support both the original jansi library and the newer jline jansi
+                        ansi = Class.forName("org.fusesource.jansi.Ansi");
+                    } catch (ClassNotFoundException e) {
+                        ansi = Class.forName("org.jline.jansi.Ansi");
+                    }
                     Boolean enabled = (Boolean) ansi.getDeclaredMethod("isEnabled").invoke(null);
                     if (!enabled) {
                         return false;
                     }
-                    // loading this class will load the native library org.fusesource.jansi.internal.CLibrary
-                    Class<?> ansiConsole = Class.forName("org.fusesource.jansi.AnsiConsole");
-                    Field out = ansiConsole.getField("out");
-                    return out.get(null) == System.out;
+                    // loading this class will load the native library org.jline.jansi.internal.CLibrary
+                    Class<?> ansiConsole;
+                    try {
+                        ansiConsole = Class.forName("org.fusesource.jansi.AnsiConsole");
+                    } catch (ClassNotFoundException e) {
+                        ansiConsole = Class.forName("org.jline.jansi.AnsiConsole");
+                    }
+                    Object out = ansiConsole.getDeclaredMethod("out").invoke(null);
+                    return out == System.out;
                 } catch (Exception reflectionFailed) {
                     return false;
                 }

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -17990,7 +17990,7 @@ public class CommandLine {
                     }
                     try {
                         return (Boolean) ansiConsole.getDeclaredMethod("isInstalled").invoke(null);
-                    } catch (ReflectiveOperationException e) {
+                    } catch (Exception e) {
                         // isInstalled was "only" added in 2.1.0, try to support older jansi
                         Field out = ansiConsole.getField("out");
                         return out.get(null) == System.out;


### PR DESCRIPTION
Jansi has been merged into JLine, which changes the package name (and the system property name).
This pr updates the code to use the updated package name.
Support for the old name is kept to avoid breaking changes. (though I can remove it if it's not wanted)

I chose to prefer the older one if both versions are available to avoid potential breakages, but I can change that if choosing a more up to date version is preferred.

~~Note: the `out` field is `private` in the new versions, ~~so I switched to the method with the same name (which has always been there so there is no compatibility concern)~~ so I switched to calling `isInstalled` instead (which should be more correct anyway). This means Jansi versions older than 2.1.0 will not work. Hopefully that's not a problem.~~
To support both old and new versions of Jansi, it will first try to call `isInstalled` (which should be more correct anyway) and only fall back to the previous method if `isInstalled` is not present.

Fixes #2437