### PR TITLE
Fix #2407 when @ArgGroup is reused

### DIFF
--- a/picocli-codegen-tests-java9plus/src/test/java/picocli/annotation/processing/tests/Issue2407Test.java
+++ b/picocli-codegen-tests-java9plus/src/test/java/picocli/annotation/processing/tests/Issue2407Test.java
@@ -2,7 +2,6 @@ package picocli.annotation.processing.tests;
 
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.JavaFileObjects;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.annotation.processing.Processor;
@@ -12,7 +11,6 @@ import static com.google.testing.compile.Compiler.javac;
 
 public class Issue2407Test
 {
-    @Ignore("https://github.com/remkop/picocli/issues/2407")
     @Test
     public void testIssue2407() {
         Processor processor = new AnnotatedCommandSourceGeneratorProcessor();

--- a/picocli-codegen/src/main/java/picocli/codegen/annotation/processing/AbstractCommandSpecProcessor.java
+++ b/picocli-codegen/src/main/java/picocli/codegen/annotation/processing/AbstractCommandSpecProcessor.java
@@ -522,7 +522,12 @@ public abstract class AbstractCommandSpecProcessor extends AbstractProcessor {
 
             DeclaredType declaredType = getDeclaredTypeForArgGroupVarOrMethod(element, this);
             if (declaredType != null) {
-                context.argGroupElementsByType.put(declaredType, builder);
+                List<ArgGroupSpec.Builder> existingBuilders = context.argGroupElementsByType.get(declaredType);
+                if (existingBuilders == null) {
+                    existingBuilders = new ArrayList<ArgGroupSpec.Builder>();
+                    context.argGroupElementsByType.put(declaredType, existingBuilders);
+                }
+                existingBuilders.add(builder);
                 processEnclosedElements(context, roundEnv, declaredType.asElement().getEnclosedElements());
             }
         }
@@ -638,7 +643,12 @@ public abstract class AbstractCommandSpecProcessor extends AbstractProcessor {
 
                 DeclaredType declaredType = getDeclaredTypeForArgGroupVarOrMethod(variable, this);
                 if (declaredType != null) {
-                    context.argGroupElementsByType.put(declaredType, builder);
+                    List<ArgGroupSpec.Builder> existingBuilders = context.argGroupElementsByType.get(declaredType);
+                    if (existingBuilders == null) {
+                        existingBuilders = new ArrayList<ArgGroupSpec.Builder>();
+                        context.argGroupElementsByType.put(declaredType, existingBuilders);
+                    }
+                    existingBuilders.add(builder);
                 }
 
             } else if (!isMixin) { // params without any annotation are also positional
@@ -859,7 +869,7 @@ public abstract class AbstractCommandSpecProcessor extends AbstractProcessor {
         Map<Element, OptionSpec.Builder> options = new LinkedHashMap<Element, OptionSpec.Builder>();
         Map<Element, PositionalParamSpec.Builder> parameters = new LinkedHashMap<Element, PositionalParamSpec.Builder>();
         Map<Element, ArgGroupSpec.Builder> argGroupElementsByVar = new LinkedHashMap<Element, ArgGroupSpec.Builder>();
-        Map<DeclaredType, ArgGroupSpec.Builder> argGroupElementsByType = new LinkedHashMap<DeclaredType, ArgGroupSpec.Builder>();
+        Map<DeclaredType, List<ArgGroupSpec.Builder>> argGroupElementsByType = new LinkedHashMap<DeclaredType, List<ArgGroupSpec.Builder>>();
         Map<CommandSpec, Set<MixinInfo>> mixinInfoMap = new IdentityHashMap<CommandSpec, Set<MixinInfo>>();
         Map<Element, IAnnotatedElement> parentCommandElements = new LinkedHashMap<Element, IAnnotatedElement>();
         Map<Element, IAnnotatedElement> specElements = new LinkedHashMap<Element, IAnnotatedElement>();
@@ -882,10 +892,12 @@ public abstract class AbstractCommandSpecProcessor extends AbstractProcessor {
 
             for (Map.Entry<Element, OptionSpec.Builder> option : options.entrySet()) {
                 TypeMirror typeMirror = option.getKey().getEnclosingElement().asType();
-                ArgGroupSpec.Builder group = argGroupElementsByType.get(typeMirror);
-                if (group != null) {
-                    logger.fine("Building OptionSpec for " + option + " in arg group " + group);
-                    group.addArg(option.getValue().build());
+                List<ArgGroupSpec.Builder> groups = argGroupElementsByType.get(typeMirror);
+                if (groups != null && !groups.isEmpty()) {
+                    for (ArgGroupSpec.Builder group : groups) {
+                        logger.fine("Building OptionSpec for " + option + " in arg group " + group);
+                        group.addArg(option.getValue().build());
+                    }
                 } else {
                     CommandSpec commandSpec = getOrCreateCommandSpecForArg(option.getKey(), commands);
                     logger.fine("Building OptionSpec for " + option + " in spec " + commandSpec);
@@ -894,10 +906,12 @@ public abstract class AbstractCommandSpecProcessor extends AbstractProcessor {
             }
             for (Map.Entry<Element, PositionalParamSpec.Builder> parameter : parameters.entrySet()) {
                 TypeMirror typeMirror = parameter.getKey().getEnclosingElement().asType();
-                ArgGroupSpec.Builder group = argGroupElementsByType.get(typeMirror);
-                if (group != null) {
-                    logger.fine("Building PositionalParamSpec for " + parameter + " in arg group " + group);
-                    group.addArg(parameter.getValue().build());
+                List<ArgGroupSpec.Builder> groups = argGroupElementsByType.get(typeMirror);
+                if (groups != null && !groups.isEmpty()) {
+                    for (ArgGroupSpec.Builder group : groups) {
+                        logger.fine("Building PositionalParamSpec for " + parameter + " in arg group " + group);
+                        group.addArg(parameter.getValue().build());
+                    }
                 } else {
                     CommandSpec commandSpec = getOrCreateCommandSpecForArg(parameter.getKey(), commands);
                     logger.fine("Building PositionalParamSpec for " + parameter);


### PR DESCRIPTION
This change preserves all instances of the same @ArgGroup across all commands it is applied to.

fixes #2407 

---
It looks like when an ArgGroup is reused, it is overwritten in argGroupElementsByType when being parsed (but not in argGroupElementsByVar which has actual unique keys). This means when iterating through argGroupElementsByVar later in the process, it hits ArgGroupBuilders that were not fully populated in connectModel() (which iterates over argGroupElementsByType), leading to a failure to fully realize the ArgGroupSpec in its constructor (when args.isEmpty() and subgroups.isEmpty()).