### PR TITLE
Allow @Spec on method parameters for method-based subcommands

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -46,6 +46,7 @@ import picocli.CommandLine.Help.Ansi.Style;
 import picocli.CommandLine.Help.Ansi.Text;
 import picocli.CommandLine.Model.*;
 import picocli.CommandLine.ParseResult.GroupMatchContainer;
+import picocli.CommandLine.Spec;
 
 import static java.util.Locale.ENGLISH;
 import static picocli.CommandLine.Help.Column.Overflow.SPAN;
@@ -4486,7 +4487,7 @@ public class CommandLine {
      * @since 3.2
      */
     @Retention(RetentionPolicy.RUNTIME)
-    @Target({ElementType.FIELD, ElementType.METHOD})
+    @Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
     public @interface Spec {
         /** Identifies what kind of {@code CommandSpec} should be injected.
          * @since 4.3.0 */
@@ -7170,6 +7171,10 @@ public class CommandLine {
                 CommandSpec autoHelpMixin = mixins.get(AutoHelpMixin.KEY);
                 int argIndex = autoHelpMixin == null || autoHelpMixin.inherited() ? 0 : 2;
                 for (int i = 0; i < methodParams.length; i++) {
+                    if (methodParams[i].isAnnotationPresent(Spec.class)) {
+                        values[i] = this;
+                        continue;
+                    }
                     if (methodParams[i].isAnnotationPresent(Mixin.class)) {
                         String name = methodParams[i].getAnnotation(Mixin.class).name();
                         CommandSpec mixin = mixins.get(empty(name) ? methodParams[i].name : name);
@@ -11988,6 +11993,9 @@ public class CommandLine {
                         commandSpec.addUnmatchedArgsBinding(buildUnmatchedForMember(member));
                     }
                 }
+                if (member.isAnnotationPresent(Spec.class) && member.isMethodParameter()) {
+                    return false;
+                }
                 if (member.isArgSpec()) {
                     validateArgSpecMember(member);
                     if (groupBuilder != null) {
@@ -12022,7 +12030,10 @@ public class CommandLine {
                     MethodParam param = new MethodParam(method, i);
                     if (param.isAnnotationPresent(Option.class) || param.isAnnotationPresent(Mixin.class) || param.isAnnotationPresent(ArgGroup.class)) {
                         optionCount++;
-                    } else {
+                    } else if (param.isAnnotationPresent(Spec.class)){
+                            // Skipping the optionCount, since @Spec is not an option.
+                    }
+                    else {
 
                         param.position = i - optionCount;
                     }


### PR DESCRIPTION
This PR addresses issue #1670 by allowing `@Spec` to be used on method parameters in method-based subcommands.

### Changes:
- Added `ElementType.PARAMETER` to `@Spec` to enable usage on method parameters.
- Inject the correct `CommandSpec` via `commandMethodParamValues()` for method subcommands.
- Prevent `@Spec` parameters from being treated as CLI arguments.
- Scoped the change to method parameters to avoid affecting existing behavior.
- Verified that all existing tests pass.

### Motivation:
Previously, method-based subcommands could not directly receive a `CommandSpec` via a parameter, forcing developers to use fragile workarounds like looking up the subcommand from the parent spec. This PR provides a clean and safe way to inject the subcommand's `CommandSpec`.

### Example usage:

```java
import picocli.CommandLine;
import picocli.CommandLine.Command;
import picocli.CommandLine.Spec;
import picocli.CommandLine.Model.CommandSpec;

@Command(name = "app", subcommands = {TestApp.class})
public class TestApp {

    public static void main(String[] args) {
        CommandLine cmd = new CommandLine(new TestApp());
        cmd.execute(args);
    }

    @Command(name = "sub")
    void sub(@Spec CommandSpec spec) {
        System.out.println("Subcommand name: " + spec.name());
    }
}


```

Example run :

```
$ java -cp .:build/libs/picocli-4.7.8-SNAPSHOT.jar TestApp sub
Subcommand name: sub
```


Fixes: #1670