### PR TITLE
Documentation: explain `hideParamSyntax` with example

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -6258,13 +6258,15 @@ Usage: <main class> [-AbeEnstTuv] [--help] [--version] [FILE...]
 === Parameter Labels
 Non-boolean options require a value. The usage help should explain this, and picocli shows the option parameter
 in the synopsis and in the option list. By default, the field name is shown in `<` and `>` fish brackets.
-Use the `paramLabel` attribute to display a different name. For example:
+Use the `paramLabel` attribute to display a different name. For manual control with no automatic formatting,
+such as the two parameter case below, consider setting `hideParamSyntax=false`. For example:
 ----
 Usage: <main class> [-f=FILE] [-n=<number>] NUM <host>
       NUM        number param
       host       the host parameter
   -f= FILE       a file
   -n= <number>   a number option
+  -d= NAME BODY  option with two params
 ----
 Some annotated fields in the below example class have a `paramLabel` attribute and others don't:
 
@@ -6277,6 +6279,7 @@ class ParamLabels {
     @Option(names = "-n",    description = "a number option")                   int number;
     @Parameters(index = "0", description = "number param", paramLabel = "NUM")  int n;
     @Parameters(index = "1", description = "the host parameter")                InetAddress host;
+    @Option(names = "-d", arity = "2", description = "option with two params", paramLabel = "NAME BODY", hideParamSyntax = true)
 }
 ----
 

--- a/docs/quick-guide.adoc
+++ b/docs/quick-guide.adoc
@@ -763,13 +763,15 @@ Usage: <main class> [-AbeEnstTuv] [--help] [--version] [FILE...]
 ==== Parameter Labels
 Non-boolean options require a value. The usage help should explain this, and picocli shows the option parameter
 in the synopsis and in the option list. By default, the field name is shown in `<` and `>` fish brackets.
-Use the `paramLabel` attribute to display a different name. For example:
+Use the `paramLabel` attribute to display a different name. For manual control with no automatic formatting,
+such as the two parameter case below, consider setting `hideParamSyntax=false`. For example:
 ----
 Usage: <main class> [-f=FILE] [-n=<number>] NUM <host>
       NUM        number param
       host       the host
   -f= FILE       a file
   -n= <number>   number option
+  -d= NAME BODY  option with two params
 ----
 Some annotated fields in the below example class have a `paramLabel` attribute and others don't:
 [source,java]
@@ -780,6 +782,7 @@ class ParamLabels {
     @Option(names = "-n",    description = "number option")                     int number;
     @Parameters(index = "0", description = "number param", paramLabel = "NUM")  int n;
     @Parameters(index = "1", description = "the host")                          InetAddress host;
+    @Option(names = "-d", arity = "2", description = "option with two params", paramLabel = "NAME BODY", hideParamSyntax = true)
 }
 ----
 

--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -3922,7 +3922,9 @@ public class CommandLine {
 
         /** Returns whether usage syntax decorations around the {@linkplain #paramLabel() paramLabel} should be suppressed.
          * The default is {@code false}: by default, the paramLabel is surrounded with {@code '['} and {@code ']'} characters
-         * if the value is optional and followed by ellipses ("...") when multiple values can be specified.
+         * if the value is optional and followed by ellipses ("...") when multiple values can be specified, and the parameter
+         * label is repeated for each parameter for multi-arity options. Should be disabled if full control over the formating
+         * is desired, such as different labels for each parameter.
          * @since 3.6.0 */
         boolean hideParamSyntax() default false;
 


### PR DESCRIPTION
Improves documentation for `hideParamSyntax`, including example for a multi-parameter case as discussed in #2511.