### PR TITLE
[#2516] Hide user prompt if stdin is not connected to a terminal

### DIFF
--- a/src/main/java/picocli/CommandLine.java
+++ b/src/main/java/picocli/CommandLine.java
@@ -14993,14 +14993,19 @@ public class CommandLine {
 
         char[] readUserInput(ArgSpec argSpec) {
             String name = argSpec.isOption() ? ((OptionSpec) argSpec).longestName() : "position " + position;
-            String desc = str(argSpec.description(), 0);
-            String standardPrompt = empty(desc) ? String.format("Enter value for %s: ", name) : String.format("Enter value for %s (%s): ", name, desc);
-            String prompt = empty(argSpec.prompt()) ? standardPrompt : argSpec.prompt();
+
+            if (Help.Ansi.isTTY()) {
+                String desc = str(argSpec.description(), 0);
+                String standardPrompt = empty(desc) ? String.format("Enter value for %s: ", name) : String.format("Enter value for %s (%s): ", name, desc);
+                String prompt = empty(argSpec.prompt()) ? standardPrompt : argSpec.prompt();
+                System.out.print(prompt);
+            }
+
             try {
                 Tracer t = tracer();
                 if (t.isDebug()) {
                     t.debug("Reading value for %s from console...", name);}
-                char[] result = argSpec.echo() ? readUserInputWithEchoing(prompt) : readPassword(prompt);
+                char[] result = argSpec.echo() ? readUserInputWithEchoing() : readPassword();
                 if (t.isDebug()) {
                     t.debug(createUserInputDebugString(argSpec, result, name));}
                 return result;
@@ -15013,17 +15018,16 @@ public class CommandLine {
                 String.format("User entered %s for %s.%n", new String(result), name) :
                 String.format("User entered %d characters for %s.%n", result.length, name);
         }
-        char[] readPassword(String prompt) {
+        char[] readPassword() {
             try {
                 Object console = System.class.getDeclaredMethod("console").invoke(null);
-                Method method = Class.forName("java.io.Console").getDeclaredMethod("readPassword", String.class, Object[].class);
-                return (char[]) method.invoke(console, prompt, new Object[0]);
+                Method method = Class.forName("java.io.Console").getDeclaredMethod("readPassword");
+                return (char[]) method.invoke(console);
             } catch (Exception e) {
-                return readUserInputWithEchoing(prompt);
+                return readUserInputWithEchoing();
             }
         }
-        char[] readUserInputWithEchoing(String prompt) {
-            System.out.print(prompt);
+        char[] readUserInputWithEchoing() {
             InputStreamReader isr = new InputStreamReader(System.in);
             BufferedReader in = new BufferedReader(isr);
             try {

--- a/src/test/java/picocli/InteractiveArgTest.java
+++ b/src/test/java/picocli/InteractiveArgTest.java
@@ -6,6 +6,8 @@ import org.junit.Test;
 import org.junit.contrib.java.lang.system.ProvideSystemProperty;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.rules.TestRule;
+
+import picocli.CommandLine.Help;
 import picocli.CommandLine.Model.ArgSpec;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
@@ -37,11 +39,13 @@ public class InteractiveArgTest {
         PrintStream out = System.out;
         PrintStream err = System.err;
         InputStream in = System.in;
+        Boolean isTTY = Help.Ansi.tty;
 
         void reset() {
             System.setOut(out);
             System.setOut(err);
             System.setIn(in);
+            Help.Ansi.tty = isTTY;
         }
     }
 
@@ -54,8 +58,13 @@ public class InteractiveArgTest {
         }
 
         Capture(String input) {
+            this(input, true);
+        }
+
+        Capture(String input, boolean isTTY) {
             System.setOut(new PrintStream(baos));
             System.setErr(new PrintStream(errBaos));
+            Help.Ansi.tty = isTTY;
             if (input != null) {
                 System.setIn(new ByteArrayInputStream(input.getBytes()));
             }
@@ -132,6 +141,44 @@ public class InteractiveArgTest {
     }
 
     @Test
+    public void testInteractiveOptionReadsFromStdInNoTTY() {
+        org.junit.Assume.assumeTrue(System.getProperty("java.version").compareTo("22") < 0);
+        class App {
+            @Option(names = "-x", description = {"Pwd", "line2"}, interactive = true) int x;
+            @Option(names = "-z") int z;
+        }
+
+        Streams streams = new Streams();
+        System.setProperty("picocli.trace", "DEBUG");
+        try {
+            Capture capture = new Capture("1234567890", false);
+
+            App app = new App();
+            CommandLine cmd = new CommandLine(app);
+            ParseResult result = cmd.parseArgs("-x");
+            ArgSpec specX = result.matchedArgs().get(0);
+            assertThat(specX.toString(), containsString("App.x"));
+
+            assertEquals("", capture.out());
+            assertEquals(1234567890, app.x);
+            assertEquals(0, app.z);
+
+            String trace = capture.err();
+            assertThat(trace, containsString("User entered 10 characters"));
+            assertThat(trace, containsString(
+                "Setting " + specX.toString() + " to *****(masked) (interactive value)"));
+            assertThat(trace, not(containsString("1234567890")));
+
+            cmd.parseArgs("-z", "678");
+
+            assertEquals(0, app.x);
+            assertEquals(678, app.z);
+        } finally {
+            streams.reset();
+        }
+    }
+
+    @Test
     public void testInteractiveOptionReadsFromStdInWithEchoing() {
         class App {
             @Option(names = "-x", description = {"Pwd", "line2"}, interactive = true, echo = true) int x;
@@ -149,6 +196,37 @@ public class InteractiveArgTest {
             assertThat(specX.toString(), containsString("App.x"));
 
             assertEquals("Enter value for -x (Pwd): ", capture.out());
+            assertEquals(1234567890, app.x);
+
+            String trace = capture.err();
+            assertThat(trace, containsString("User entered 1234567890"));
+            assertThat(trace, containsString(
+                "Setting " + specX.toString() + " to 1234567890"));
+            assertThat(trace, not(containsString("10 characters")));
+            assertThat(trace, not(containsString("***")));
+        } finally {
+            streams.reset();
+        }
+    }
+
+    @Test
+    public void testInteractiveOptionReadsFromStdInWithEchoingNoTTY() {
+        class App {
+            @Option(names = "-x", description = {"Pwd", "line2"}, interactive = true, echo = true) int x;
+        }
+
+        Streams streams = new Streams();
+        System.setProperty("picocli.trace", "DEBUG");
+        try {
+            Capture capture = new Capture("1234567890", false);
+
+            App app = new App();
+            CommandLine cmd = new CommandLine(app);
+            ParseResult result = cmd.parseArgs("-x");
+            ArgSpec specX = result.matchedArgs().get(0);
+            assertThat(specX.toString(), containsString("App.x"));
+
+            assertEquals("", capture.out());
             assertEquals(1234567890, app.x);
 
             String trace = capture.err();


### PR DESCRIPTION
- Moved prompt into parent method and check if there's a tty.
- Removed the builtin prompt provided by Console.readPassword.
- Fixed existing interactive tests that rely on tty=true.
- Added test cases for tty=false asserting stdout is empty.

Manual testing using the cryptomator CLI use case mentioned in the issue.

```
$ cryptomator-cli create /tmp/testVault --password:stdin
Enter value for --password:stdin (Passphrase, read from STDIN): <type password>
Confirm passphrase: <type password>

[main] INFO  o.c.cli.Create - Vault created successfully in /tmp/testVault

$ echo test123 | cryptomator-cli create /tmp/testVault --password:stdin
[main] INFO  o.c.cli.Create - Vault created successfully in /tmp/testVault
```

Fixes #2516